### PR TITLE
Add per window type option full-shadow

### DIFF
--- a/compton.sample.conf
+++ b/compton.sample.conf
@@ -83,5 +83,5 @@ glx-swap-method = "undefined";
 # Window type settings
 wintypes:
 {
-  tooltip = { fade = true; shadow = true; opacity = 0.75; focus = true; };
+  tooltip = { fade = true; shadow = true; opacity = 0.75; focus = true; full-shadow = false; };
 };

--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -372,11 +372,25 @@ compton uses general libconfig configuration file format. A sample configuration
 ------------
 wintypes:
 {
-  WINDOW_TYPE = { fade = BOOL; shadow = BOOL; opacity = FLOAT; focus = BOOL; };
+  WINDOW_TYPE = { fade = BOOL; shadow = BOOL; opacity = FLOAT; focus = BOOL; full-shadow = BOOL; };
 };
 ------------
 
-'WINDOW_TYPE' is one of the 15 window types defined in EWMH standard: "unknown", "desktop", "dock", "toolbar", "menu", "utility", "splash", "dialog", "normal", "dropdown_menu", "popup_menu", "tooltip", "notify", "combo", and "dnd". "fade" and "shadow" controls window-type-specific shadow and fade settings. "opacity" controls default opacity of the window type. "focus" controls whether the window of this type is to be always considered focused. (By default, all window types except "normal" and "dialog" has this on.)
+'WINDOW_TYPE' is one of the 15 window types defined in EWMH standard: "unknown", "desktop", "dock", "toolbar", "menu", "utility", "splash", "dialog", "normal", "dropdown_menu", "popup_menu", "tooltip", "notify", "combo", and "dnd".
+
+Following per window-type options are available: ::
+
+  fade, shadow:::
+    Controls window-type-specific shadow and fade settings.
+
+  opacity:::
+    Controls default opacity of the window type.
+
+  focus:::
+    Controls whether the window of this type is to be always considered focused. (By default, all window types except "normal" and "dialog" has this on.)
+
+  full-shadow:::
+    Controls whether shadow is drawn under the parts of the window that you normally won't be able to see. Useful when the window has parts of it transparent, and you want shadows in those areas.
 
 SIGNALS
 -------

--- a/src/common.h
+++ b/src/common.h
@@ -531,6 +531,7 @@ typedef struct options_t {
   // === Shadow ===
   /// Enable/disable shadow for specific window types.
   bool wintype_shadow[NUM_WINTYPES];
+  bool wintype_full_shadow[NUM_WINTYPES];
   /// Red, green and blue tone of the shadow.
   double shadow_red, shadow_green, shadow_blue;
   int shadow_radius;

--- a/src/compton.c
+++ b/src/compton.c
@@ -4038,7 +4038,9 @@ get_cfg(session_t *ps, int argc, char *const *argv, bool first_pass) {
         ps->o.frame_opacity = atof(optarg);
         break;
       case 'z':
-        printf_errf("(): clear-shadow is removed, shadows are automatically cleared now.");
+        printf_errf("(): clear-shadow is removed, shadows are automatically cleared now.\n"
+          "If you want to prevent shadow from been cleared under certain types of windows,\n"
+          "you can use the \"full-shadow\" per window type option.");
         break;
       case 'n':
       case 'a':

--- a/src/compton.c
+++ b/src/compton.c
@@ -1915,10 +1915,11 @@ paint_all(session_t *ps, region_t *region, const region_t *region_real, win * co
         w->g.x + w->shadow_dx, w->g.y + w->shadow_dy,
         w->shadow_width, w->shadow_height);
 
-      // Mask out the body of the window from the shadow
+      // Mask out the body of the window from the shadow if needed
       // Doing it here instead of in make_shadow() for saving GPU
       // power and handling shaped windows (XXX unconfirmed)
-      pixman_region32_subtract(&reg_tmp, &reg_tmp, &bshape);
+      if (!ps->o.wintype_full_shadow[w->window_type])
+        pixman_region32_subtract(&reg_tmp, &reg_tmp, &bshape);
 
 #ifdef CONFIG_XINERAMA
       if (ps->o.xinerama_shadow_crop && w->xinerama_scr >= 0 &&
@@ -4228,6 +4229,7 @@ get_cfg(session_t *ps, int argc, char *const *argv, bool first_pass) {
   cfgtmp.menu_opacity = normalize_d(cfgtmp.menu_opacity);
   ps->o.refresh_rate = normalize_i_range(ps->o.refresh_rate, 0, 300);
   ps->o.alpha_step = normalize_d_range(ps->o.alpha_step, 0.01, 1.0);
+
   if (shadow_enable)
     wintype_arr_enable(ps->o.wintype_shadow);
   ps->o.wintype_shadow[WINTYPE_DESKTOP] = false;
@@ -4237,6 +4239,7 @@ get_cfg(session_t *ps, int argc, char *const *argv, bool first_pass) {
     ps->o.wintype_shadow[WINTYPE_DND] = false;
   if (fading_enable)
     wintype_arr_enable(ps->o.wintype_fade);
+
   if (!safe_isnan(cfgtmp.menu_opacity)) {
     ps->o.wintype_opacity[WINTYPE_DROPDOWN_MENU] = cfgtmp.menu_opacity;
     ps->o.wintype_opacity[WINTYPE_POPUP_MENU] = cfgtmp.menu_opacity;
@@ -5049,6 +5052,7 @@ session_init(session_t *ps_old, int argc, char **argv) {
       .vsync_aggressive = false,
 
       .wintype_shadow = { false },
+      .wintype_full_shadow = { false },
       .shadow_red = 0.0,
       .shadow_green = 0.0,
       .shadow_blue = 0.0,

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -374,6 +374,7 @@ parse_config(session_t *ps, struct options_tmp *pcfgtmp) {
 
   // Wintype settings
 
+  // XXX ! Refactor all the wintype_* arrays into a struct
   for (wintype_t i = 0; i < NUM_WINTYPES; ++i) {
     char *str = mstrjoin("wintypes.", WINTYPES[i]);
     config_setting_t *setting = config_lookup(&cfg, str);
@@ -385,6 +386,8 @@ parse_config(session_t *ps, struct options_tmp *pcfgtmp) {
         ps->o.wintype_fade[i] = (bool) ival;
       if (config_setting_lookup_bool(setting, "focus", &ival))
         ps->o.wintype_focus[i] = (bool) ival;
+      if (config_setting_lookup_bool(setting, "full-shadow", &ival))
+        ps->o.wintype_full_shadow[i] = ival;
 
       double fval;
       if (config_setting_lookup_float(setting, "opacity", &fval))


### PR DESCRIPTION
When this option is enabled for a window type, shadow will be drawn in
areas that are obscure by the shape of the window.

Useful when the given window type has parts of the window transparent,
and you want to have shadows in those areas.

Fixes #45

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>