### PR TITLE
Support all alpha values

### DIFF
--- a/compton.sample.conf
+++ b/compton.sample.conf
@@ -27,7 +27,6 @@ inactive-opacity = 0.8;
 # active-opacity = 0.8;
 frame-opacity = 0.7;
 inactive-opacity-override = false;
-alpha-step = 0.06;
 # inactive-dim = 0.2;
 # inactive-dim-fixed = true;
 # blur-background = true;

--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -148,9 +148,6 @@ OPTIONS
 *--vsync-aggressive*::
 	Attempt to send painting request before VBlank and do XFlush() during VBlank. Reported to work pretty terribly. This switch may be lifted out at any moment.
 
-*--alpha-step* 'VALUE'::
-	X Render backend: Step for pregenerating alpha pictures. (0.01 - 1.0, defaults to 0.03)
-
 *--dbe*::
 	Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing. Reported to have no effect, though.
 

--- a/src/common.h
+++ b/src/common.h
@@ -62,6 +62,8 @@
 #define DEBUG_BACKTRACE 1
 #endif
 
+#define MAX_ALPHA (255)
+
 // === Includes ===
 
 // For some special functions
@@ -582,8 +584,6 @@ typedef struct options_t {
   /// Whether to detect _NET_WM_OPACITY on client windows. Used on window
   /// managers that don't pass _NET_WM_OPACITY to frame windows.
   bool detect_client_opacity;
-  /// Step for pregenerating alpha pictures. 0.01 - 1.0.
-  double alpha_step;
 
   // === Other window processing ===
   /// Whether to blur background of semi-transparent / ARGB windows.

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -295,8 +295,6 @@ parse_config(session_t *ps, struct options_tmp *pcfgtmp) {
   // --backend
   if (config_lookup_string(&cfg, "backend", &sval) && !parse_backend(ps, sval))
     exit(1);
-  // --alpha-step
-  config_lookup_float(&cfg, "alpha-step", &ps->o.alpha_step);
   // --sw-opti
   lcfg_lookup_bool(&cfg, "sw-opti", &ps->o.sw_opti);
   // --use-ewmh-active-win
@@ -365,8 +363,12 @@ parse_config(session_t *ps, struct options_tmp *pcfgtmp) {
     printf_errf("(): \"paint-on-overlay\" has been removed as an option, and "
                 "is enabled whenever possible");
 
+  if (config_lookup_float(&cfg, "alpha-step", &dval))
+    printf_errf("(): \"alpha-step\" has been removed, compton now tries to make use"
+                " of all alpha values");
+
   const char *deprecation_message = "has been removed. If you encounter problems "
-    "without this feature, please feel free to open a bug report.";
+    "without this feature, please feel free to open a bug report";
   if (lcfg_lookup_bool(&cfg, "glx-use-copysubbuffermesa", &bval) && bval)
     printf_errf("(): \"glx-use-copysubbuffermesa\" %s", deprecation_message);
   if (lcfg_lookup_bool(&cfg, "glx-copy-from-front", &bval) && bval)


### PR DESCRIPTION
Remove alpha_step, and support all 256 alpha values.

1 pixel pictures don't really use that many resources.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>