### PR TITLE
Add wintype option `redir-ignore`.

### DIFF
--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -389,6 +389,9 @@ Following per window-type options are available: ::
   full-shadow:::
     Controls whether shadow is drawn under the parts of the window that you normally won't be able to see. Useful when the window has parts of it transparent, and you want shadows in those areas.
 
+  redir-ignore:::
+    Controls whether this type window should cause screen to become redirected again after been unredirected. If you have *--unredir-if-possible* set, and doesn't want certain window to cause unnecessary screen redirection, you can set this to `true`.
+
 SIGNALS
 -------
 

--- a/src/compton.c
+++ b/src/compton.c
@@ -1333,7 +1333,12 @@ paint_preprocess(session_t *ps, win *list) {
     w->flags = 0;
     w->prev_trans = t;
     t = w;
-    is_highest = false;
+
+    // If the screen is not redirected and the window has redir_ignore set,
+    // this window should not cause the screen to become redirected
+    if (!(ps->o.wintype_option[w->window_type].redir_ignore && !ps->redirected)) {
+      is_highest = false;
+    }
 
   skip_window:
     reg_ignore_valid = reg_ignore_valid && w->reg_ignore_valid;
@@ -1375,8 +1380,7 @@ paint_preprocess(session_t *ps, win *list) {
         ev_timer_start(ps->loop, &ps->unredir_timer);
       }
     }
-  }
-  else {
+  } else {
     ev_timer_stop(ps->loop, &ps->unredir_timer);
     redir_start(ps);
   }

--- a/src/config.c
+++ b/src/config.c
@@ -376,6 +376,10 @@ void parse_config(session_t *ps, bool *shadow_enable, bool *fading_enable,
       winopt_mask[i].full_shadow = true;
       ps->o.wintype_option[i].full_shadow = false;
     }
+    if (!winopt_mask[i].redir_ignore) {
+      winopt_mask[i].redir_ignore = true;
+      ps->o.wintype_option[i].redir_ignore = false;
+    }
     if (!winopt_mask[i].opacity) {
       winopt_mask[i].opacity = true;
       // Opacity is not set to a concrete number here because the opacity logic

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -260,8 +260,7 @@ void parse_config_libconfig(session_t *ps, bool *shadow_enable,
   // -m (menu_opacity)
   if (config_lookup_float(&cfg, "menu-opacity", &dval)) {
     printf_errf("(): option `menu-opacity` is deprecated, and will be removed.\n"
-      "Please use the wintype option `opacity` of `popup_menu` and\n"
-      "`dropdown_menu` instead.");
+      "Please use the wintype option `opacity` of `popup_menu` and `dropdown_menu` instead.");
     ps->o.wintype_option[WINTYPE_DROPDOWN_MENU].opacity = dval;
     ps->o.wintype_option[WINTYPE_POPUP_MENU].opacity = dval;
     winopt_mask[WINTYPE_DROPDOWN_MENU].opacity = true;
@@ -419,6 +418,10 @@ void parse_config_libconfig(session_t *ps, bool *shadow_enable,
       if (config_setting_lookup_bool(setting, "full-shadow", &ival)) {
         o->full_shadow = ival;
         mask->full_shadow = true;
+      }
+      if (config_setting_lookup_bool(setting, "redir-ignore", &ival)) {
+        o->redir_ignore = ival;
+        mask->redir_ignore = true;
       }
 
       double fval;


### PR DESCRIPTION
This cause certain window types to be ignored in deciding whether the
screen should be redirected after being unredirected.

Fixes #58

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>