### PR TITLE
Improve swap-controlled vsync for mesa

### DIFF
--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -139,8 +139,8 @@ OPTIONS
 * 'drm': VSync with 'DRM_IOCTL_WAIT_VBLANK'. May only work on some (DRI-based) drivers.
 * 'opengl': Try to VSync with 'SGI_video_sync' OpenGL extension. Only work on some drivers.
 * 'opengl-oml': Try to VSync with 'OML_sync_control' OpenGL extension. Only work on some drivers.
-* 'opengl-swc': Try to VSync with 'SGI_swap_control' OpenGL extension. Only work on some drivers. Works only with GLX backend. Known to be most effective on many drivers. Does not guarantee to control paint timing.
-* 'opengl-mswc': Try to VSync with 'MESA_swap_control' OpenGL extension. Basically the same as 'opengl-swc' above, except the extension we use.
+* 'opengl-swc': Try to VSync with 'MESA_swap_control' or 'SGI_swap_control' (in order of preference) OpenGL extension. Works only with GLX backend. Known to be most effective on many drivers. Does not guarantee to control paint timing.
+* 'opengl-mswc': Deprecated, use 'opengl-swc' instead.
 
 (Note some VSync methods may not be enabled at compile time.)
 --

--- a/src/compton.c
+++ b/src/compton.c
@@ -4566,8 +4566,8 @@ static bool
 vsync_opengl_swc_init(session_t *ps) {
 #ifdef CONFIG_OPENGL
   if (!bkend_use_glx(ps)) {
-    printf_errf("(): I'm afraid OpenGL swap control wouldn't help if you are "
-        "not using GLX backend. You could try, nonetheless.");
+    printf_errf("(): OpenGL swap control requires the GLX backend.");
+    return false;
   }
 
   if (!vsync_opengl_swc_swap_interval(ps, 1)) {
@@ -4631,7 +4631,8 @@ vsync_opengl_swc_deinit(session_t *ps) {
 bool
 vsync_init(session_t *ps) {
   // Mesa turns on swap control by default, undo that
-  vsync_opengl_swc_swap_interval(ps, 0);
+  if (bkend_use_glx(ps))
+    vsync_opengl_swc_swap_interval(ps, 0);
 
   if (ps->o.vsync && VSYNC_FUNCS_INIT[ps->o.vsync]
       && !VSYNC_FUNCS_INIT[ps->o.vsync](ps)) {

--- a/src/compton.c
+++ b/src/compton.c
@@ -4630,6 +4630,9 @@ vsync_opengl_swc_deinit(session_t *ps) {
  */
 bool
 vsync_init(session_t *ps) {
+  // Mesa turns on swap control by default, undo that
+  vsync_opengl_swc_swap_interval(ps, 0);
+
   if (ps->o.vsync && VSYNC_FUNCS_INIT[ps->o.vsync]
       && !VSYNC_FUNCS_INIT[ps->o.vsync](ps)) {
     ps->o.vsync = VSYNC_NONE;


### PR DESCRIPTION
As discussed in #25.

It turns out SGI_swap_control doesn't accept a swap interval of 0, so we need to use MESA_swap_control to disable it.
I've refactored and merged swc and mswc into one vsync method. It prefers MESA_swap_control when available and falls back to SGI_swap_control otherwise. The effects should remain the same in practice.
The old mswc option will print a warning and hand over to swc.