### PR TITLE
Fix wintypes options handling

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -269,6 +269,7 @@ parse_config_libconfig(options_t *, const char *config_file, bool *shadow_enable
                        bool *fading_enable, bool *hasneg, win_option_mask_t *winopt_mask);
 #endif
 
+void set_default_winopts(options_t *, win_option_mask_t *, bool shadow_enable, bool fading_enable);
 /// Parse a configuration file is that is enabled, also initialize the winopt_mask with
 /// default values
 /// Outputs and returns:

--- a/src/options.c
+++ b/src/options.c
@@ -793,18 +793,7 @@ void get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 	opt->refresh_rate = normalize_i_range(opt->refresh_rate, 0, 300);
 
 	// Apply default wintype options that are dependent on global options
-	for (int i = 0; i < NUM_WINTYPES; i++) {
-		auto wo = &opt->wintype_option[i];
-		auto mask = &winopt_mask[i];
-		if (!mask->shadow) {
-			wo->shadow = shadow_enable;
-			mask->shadow = true;
-		}
-		if (!mask->fade) {
-			wo->fade = fading_enable;
-			mask->fade = true;
-		}
-	}
+	set_default_winopts(opt, winopt_mask, shadow_enable, fading_enable);
 
 	// --blur-background-frame implies --blur-background
 	if (opt->blur_background_frame)

--- a/src/options.c
+++ b/src/options.c
@@ -551,11 +551,11 @@ void get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 		case 'c': shadow_enable = true; break;
 		case 'C':
 			winopt_mask[WINTYPE_DOCK].shadow = true;
-			opt->wintype_option[WINTYPE_DOCK].shadow = true;
+			opt->wintype_option[WINTYPE_DOCK].shadow = false;
 			break;
 		case 'G':
 			winopt_mask[WINTYPE_DND].shadow = true;
-			opt->wintype_option[WINTYPE_DND].shadow = true;
+			opt->wintype_option[WINTYPE_DND].shadow = false;
 			break;
 		case 'm':;
 			double tmp;


### PR DESCRIPTION
Filling winopts with default values happened too early. It should happen
after command line options have been parsed, not after parsing the
config file.

Fixes #79

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>