### PR TITLE
Fix small misspellings

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1674,7 +1674,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/bin/compton-trans
+++ b/bin/compton-trans
@@ -50,7 +50,7 @@ for v in "$@"; do
 done
 
 # This takes into account the fact that getopts stops on
-# any argument it doesn't recongize or errors on. This
+# any argument it doesn't recognize or errors on. This
 # allows for things like `compton-trans -5` as well
 # as `compton-trans -c +5 -s` (contrived example).
 while test $# -gt 0; do

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,7 @@ option('regex', type: 'boolean', value: true, description: 'Enable regex support
 option('vsync_drm', type: 'boolean', value: false, description: 'Enable support for using drm for vsync')
 
 option('opengl', type: 'boolean', value: true, description: 'Enable features that require opengl (opengl backend, and opengl vsync methods)')
-option('dbus', type: 'boolean', value: true, description: 'Enable suport for D-Bus remote control')
+option('dbus', type: 'boolean', value: true, description: 'Enable support for D-Bus remote control')
 
 option('xrescheck', type: 'boolean', value: false, description: 'Enable X resource leak checker (for debug only)')
 

--- a/src/c2.c
+++ b/src/c2.c
@@ -19,7 +19,7 @@
 #ifdef CONFIG_REGEX_PCRE
 #include <pcre.h>
 
-// For compatiblity with <libpcre-8.20
+// For compatibility with <libpcre-8.20
 #ifndef PCRE_STUDY_JIT_COMPILE
 #define PCRE_STUDY_JIT_COMPILE    0
 #define LPCRE_FREE_STUDY(extra)   pcre_free(extra)

--- a/src/render.c
+++ b/src/render.c
@@ -890,7 +890,7 @@ void paint_all(session_t *ps, win *const t, bool ignore_damage) {
 
 		// Calculate the paint region based on the reg_ignore of the current
 		// window and its bounding region.
-		// Remeber, reg_ignore is the union of all windows above the current
+		// Remember, reg_ignore is the union of all windows above the current
 		// window.
 		pixman_region32_subtract(&reg_tmp, &region, w->reg_ignore);
 		pixman_region32_intersect(&reg_tmp, &reg_tmp, &bshape);


### PR DESCRIPTION
This commit fixes some small misspellings that were found with https://github.com/client9/misspell.