### PR TITLE
Exclude shadow to AwesomeWM in default config file

### DIFF
--- a/compton.sample.conf
+++ b/compton.sample.conf
@@ -11,6 +11,7 @@ log-level = "warn";
 # shadow-blue = 0.0;
 shadow-exclude = [
 	"name = 'Notification'",
+  "class_g = 'awesome'",
 	"class_g = 'Conky'",
 	"class_g ?= 'Notify-osd'",
 	"class_g = 'Cairo-clock'",


### PR DESCRIPTION
Hi, today I encounter a problem when the v5 update hit my Arch system. I have a setup with transparent status bar with AwesomeWM. The v5 version of compton, as it change the way it renders shadows for window, start to render a shadow for my status bar, which is an undesired effect.

Knowning most Awesome users make heavy customizations with their desktop, I think is better to exclude shadows for anything awesome related.

I don't know how it's generated the default config file, if it's distro specific but if it can be change here it would be ideal. 