### PR TITLE
meson.build: bump project version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('compton', 'c', version: '4',
+project('compton', 'c', version: '5',
         default_options: ['c_std=c11'])
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
Trivial fixup, may want it to be 5.1 or w/e, not sure.
(but pretty sure '4' is wrong regardless :))