### PR TITLE
Use struct conv for blur kernel as well

### DIFF
--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -15,6 +15,7 @@
 #include "region.h"
 #include "string_utils.h"
 #include "utils.h"
+#include "kernel.h"
 
 #include "backend/gl/gl_common.h"
 
@@ -678,13 +679,10 @@ bool gl_create_blur_filters(session_t *ps, gl_blur_shader_t *passes, const gl_ca
 	}
 
 	for (int i = 0; i < MAX_BLUR_PASS && ps->o.blur_kerns[i]; ++i) {
-		xcb_render_fixed_t *kern = ps->o.blur_kerns[i];
-		if (!kern)
-			break;
-
+		auto kern = ps->o.blur_kerns[i];
 		// Build shader
-		int wid = XFIXED_TO_DOUBLE(kern[0]), hei = XFIXED_TO_DOUBLE(kern[1]);
-		int nele = wid * hei - 1;
+		int width = kern->w, height = kern->h;
+		int nele = width * height - 1;
 		unsigned int len =
 		    strlen(FRAG_SHADER_BLUR_PREFIX) + strlen(sampler_type) +
 		    strlen(extension) + (strlen(shader_add) + strlen(texture_func) + 42) * nele +
@@ -696,15 +694,16 @@ bool gl_create_blur_filters(session_t *ps, gl_blur_shader_t *passes, const gl_ca
 		assert(strlen(shader_str) < len);
 
 		double sum = 0.0;
-		for (int j = 0; j < hei; ++j) {
-			for (int k = 0; k < wid; ++k) {
-				if (hei / 2 == j && wid / 2 == k)
+		for (int j = 0; j < height; ++j) {
+			for (int k = 0; k < width; ++k) {
+				if (height / 2 == j && width / 2 == k)
 					continue;
-				double val = XFIXED_TO_DOUBLE(kern[2 + j * wid + k]);
-				if (0.0 == val)
+				double val = kern->data[j * width + k];
+				if (val == 0) {
 					continue;
+				}
 				sum += val;
-				sprintf(pc, shader_add, val, texture_func, k - wid / 2, j - hei / 2);
+				sprintf(pc, shader_add, val, texture_func, k - width / 2, j - height / 2);
 				pc += strlen(pc);
 				assert(strlen(shader_str) < len);
 			}

--- a/src/common.h
+++ b/src/common.h
@@ -127,10 +127,6 @@
 // Window opacity / dim state changed
 #define WFLAG_OPCT_CHANGE   0x0004
 
-// xcb-render specific macros
-#define XFIXED_TO_DOUBLE(value) (((double) (value)) / 65536)
-#define DOUBLE_TO_XFIXED(value) ((xcb_render_fixed_t) (((double) (value)) * 65536))
-
 // === Types ===
 typedef struct glx_fbconfig glx_fbconfig_t;
 

--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,7 @@
 #include "compiler.h"
 #include "win.h"
 #include "types.h"
+#include "kernel.h"
 
 typedef struct session session_t;
 
@@ -207,7 +208,7 @@ typedef struct options_t {
 	/// Background blur blacklist. A linked list of conditions.
 	c2_lptr_t *blur_background_blacklist;
 	/// Blur convolution kernel.
-	xcb_render_fixed_t *blur_kerns[MAX_BLUR_PASS];
+	conv *blur_kerns[MAX_BLUR_PASS];
 	/// How much to dim an inactive window. 0.0 - 1.0, 0 to disable.
 	double inactive_dim;
 	/// Whether to use fixed inactive dim opacity, instead of deciding
@@ -245,13 +246,8 @@ extern const char *const VSYNC_STRS[NUM_VSYNC + 1];
 extern const char *const BACKEND_STRS[NUM_BKEND + 1];
 
 attr_warn_unused_result bool parse_long(const char *, long *);
-attr_warn_unused_result const char *parse_matrix_readnum(const char *, double *);
-attr_warn_unused_result xcb_render_fixed_t *
-parse_matrix(const char *, const char **, bool *hasneg);
-attr_warn_unused_result xcb_render_fixed_t *
-parse_conv_kern(const char *, const char **, bool *hasneg);
 attr_warn_unused_result bool
-parse_conv_kern_lst(const char *, xcb_render_fixed_t **, int, bool *hasneg);
+parse_blur_kern_lst(const char *, conv **, int, bool *hasneg);
 attr_warn_unused_result bool parse_geometry(session_t *, const char *, region_t *);
 attr_warn_unused_result bool parse_rule_opacity(c2_lptr_t **, const char *);
 

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -379,7 +379,7 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
       &opt->blur_background_fixed);
   // --blur-kern
   if (config_lookup_string(&cfg, "blur-kern", &sval) &&
-      !parse_conv_kern_lst(sval, opt->blur_kerns, MAX_BLUR_PASS, conv_kern_hasneg)) {
+      !parse_blur_kern_lst(sval, opt->blur_kerns, MAX_BLUR_PASS, conv_kern_hasneg)) {
     log_fatal("Cannot parse \"blur-kern\"");
     goto err;
   }

--- a/src/options.c
+++ b/src/options.c
@@ -711,7 +711,7 @@ void get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 			break;
 		case 301:
 			// --blur-kern
-			if (!parse_conv_kern_lst(optarg, opt->blur_kerns,
+			if (!parse_blur_kern_lst(optarg, opt->blur_kerns,
 			                         MAX_BLUR_PASS, &conv_kern_hasneg))
 				exit(1);
 			break;
@@ -818,35 +818,18 @@ void get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 
 	// Fill default blur kernel
 	if (opt->blur_background && !opt->blur_kerns[0]) {
-		// Convolution filter parameter (box blur)
-		// gaussian or binomial filters are definitely superior, yet looks
-		// like they aren't supported as of xorg-server-1.13.0
-		static const xcb_render_fixed_t convolution_blur[] = {
-		    // Must convert to XFixed with DOUBLE_TO_XFIXED()
-		    // Matrix size
-		    DOUBLE_TO_XFIXED(3),
-		    DOUBLE_TO_XFIXED(3),
-		    // Matrix
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		    DOUBLE_TO_XFIXED(1),
-		};
-		opt->blur_kerns[0] = ccalloc(ARR_SIZE(convolution_blur), xcb_render_fixed_t);
-		memcpy(opt->blur_kerns[0], convolution_blur, sizeof(convolution_blur));
+		bool ret = parse_blur_kern_lst("3x3box", opt->blur_kerns, MAX_BLUR_PASS, &conv_kern_hasneg);
+		assert(ret);
 	}
 
-	if (opt->resize_damage < 0)
+	if (opt->resize_damage < 0) {
 		log_warn("Negative --resize-damage will not work correctly.");
+	}
 
-	if (opt->backend == BKEND_XRENDER && conv_kern_hasneg)
+	if (opt->backend == BKEND_XRENDER && conv_kern_hasneg) {
 		log_warn("A convolution kernel with negative values may not work "
 		         "properly under X Render backend.");
+	}
 }
 
 // vim: set noet sw=8 ts=8 :

--- a/src/x.h
+++ b/src/x.h
@@ -12,6 +12,7 @@
 
 #include "compiler.h"
 #include "region.h"
+#include "kernel.h"
 
 typedef struct session session_t;
 
@@ -167,3 +168,15 @@ xcb_pixmap_t x_get_root_back_pixmap(session_t *ps);
 bool x_is_root_back_pixmap_atom(session_t *ps, xcb_atom_t atom);
 
 bool x_fence_sync(xcb_connection_t *, xcb_sync_fence_t);
+
+/**
+ * Set the picture filter of a xrender picture to a convolution
+ * kernel.
+ *
+ * @param c   xcb connection
+ * @param pict the picture
+ * @param kern the convolution kernel
+ */
+void
+x_set_picture_convolution_kernel(xcb_connection_t *c,
+                                 xcb_render_picture_t pict, conv *kernel);


### PR DESCRIPTION
instead of keeping them as an array of xfixed.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>