### PR TITLE
Deprecate --glx-swap-method

### DIFF
--- a/compton.sample.conf
+++ b/compton.sample.conf
@@ -70,8 +70,8 @@ invert-color-include = [ ];
 # GLX backend
 # glx-no-stencil = true;
 # glx-no-rebind-pixmap = true;
-glx-swap-method = "undefined";
 # xrender-sync-fence = true;
+use-damage = true;
 
 # Window type settings
 wintypes:

--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -203,7 +203,7 @@ May also be one of the predefined kernels: `3x3box` (default), `5x5box`, `7x7box
 	Exclude conditions for background blur.
 
 *--resize-damage* 'INTEGER'::
-	Resize damaged region by a specific number of pixels. A positive value enlarges it while a negative one shrinks it. If the value is positive, those additional pixels will not be actually painted to screen, only used in blur calculation, and such. (Due to technical limitations, with *--glx-swap-method*, those pixels will still be incorrectly painted to screen.) Primarily used to fix the line corruption issues of blur, in which case you should use the blur radius value here (e.g. with a 3x3 kernel, you should use *--resize-damage* 1, with a 5x5 one you use *--resize-damage* 2, and so on). May or may not work with `--glx-no-stencil`. Shrinking doesn't function correctly.
+	Resize damaged region by a specific number of pixels. A positive value enlarges it while a negative one shrinks it. If the value is positive, those additional pixels will not be actually painted to screen, only used in blur calculation, and such. (Due to technical limitations, with *--use-damage*, those pixels will still be incorrectly painted to screen.) Primarily used to fix the line corruption issues of blur, in which case you should use the blur radius value here (e.g. with a 3x3 kernel, you should use *--resize-damage* 1, with a 5x5 one you use *--resize-damage* 2, and so on). May or may not work with `--glx-no-stencil`. Shrinking doesn't function correctly.
 
 *--invert-color-include* 'CONDITION'::
 	Specify a list of conditions of windows that should be painted with inverted color. Resource-hogging, and is not well tested.
@@ -232,8 +232,8 @@ May also be one of the predefined kernels: `3x3box` (default), `5x5box`, `7x7box
 *--glx-no-rebind-pixmap*::
 	GLX backend: Avoid rebinding pixmap on window damage. Probably could improve performance on rapid window content changes, but is known to break things on some drivers (LLVMpipe, xf86-video-intel, etc.). Recommended if it works.
 
-*--glx-swap-method* undefined/exchange/copy/3/4/5/6/buffer-age::
-	GLX backend: GLX buffer swap method we assume. Could be `undefined` (0), `copy` (1), `exchange` (2), 3-6, or `buffer-age` (-1).  `undefined` is the slowest and the safest, and the default value. `copy` is fastest, but may fail on some drivers, 2-6 are gradually slower but safer (6 is still faster than 0). Usually, double buffer means 2, triple buffer means 3. `buffer-age` means auto-detect using 'GLX_EXT_buffer_age', supported by some drivers. Partially breaks `--resize-damage`. Defaults to `undefined`.
+*-use-damage*::
+	Use the damage information to limit rendering to parts of the screen that has actually changed. Potentially improves the performance.
 
 *--xrender-sync-fence*::
 	Use X Sync fence to sync clients' draw calls, to make sure all draw calls are finished before compton starts drawing. Needed on nvidia-drivers with GLX backend for some users.

--- a/src/config.h
+++ b/src/config.h
@@ -82,8 +82,6 @@ typedef struct options_t {
 	bool glx_no_stencil;
 	/// Whether to avoid rebinding pixmap on window damage.
 	bool glx_no_rebind_pixmap;
-	/// GLX swap method we assume OpenGL uses.
-	int glx_swap_method;
 	/// Custom fragment shader for painting windows, as a string.
 	char *glx_fshader_win_str;
 	/// Whether to detect rounded corners.
@@ -131,6 +129,8 @@ typedef struct options_t {
 	/// Whether to use glFinish() instead of glFlush() for (possibly) better
 	/// VSync yet probably higher CPU usage.
 	bool vsync_use_glfinish;
+	/// Whether use damage information to help limit the area to paint
+	bool use_damage;
 
 	// === Shadow ===
 	/// Red, green and blue tone of the shadow.
@@ -283,51 +283,6 @@ static inline attr_pure enum backend parse_backend(const char *str) {
 	}
 	log_error("Invalid backend argument: %s", str);
 	return NUM_BKEND;
-}
-
-/**
- * Parse a glx_swap_method option argument.
- *
- * Returns -2 on failure
- */
-static inline attr_pure int parse_glx_swap_method(const char *str) {
-	// Parse alias
-	if (!strcmp("undefined", str)) {
-		return 0;
-	}
-
-	if (!strcmp("copy", str)) {
-		return 1;
-	}
-
-	if (!strcmp("exchange", str)) {
-		return 2;
-	}
-
-	if (!strcmp("buffer-age", str)) {
-		return -1;
-	}
-
-	// Parse number
-	char *pc = NULL;
-	int age = strtol(str, &pc, 0);
-	if (!pc || str == pc) {
-		log_error("glx-swap-method is an invalid number: %s", str);
-		return -2;
-	}
-
-	for (; *pc; ++pc)
-		if (!isspace(*pc)) {
-			log_error("Trailing characters in glx-swap-method option: %s", str);
-			return -2;
-		}
-
-	if (age < -1) {
-		log_error("Number for glx-swap-method is too small: %s", str);
-		return -2;
-	}
-
-	return age;
 }
 
 /**

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -1028,7 +1028,7 @@ static bool cdbus_process_opts_get(session_t *ps, DBusMessage *msg) {
 #ifdef CONFIG_OPENGL
 	cdbus_m_opts_get_do(glx_no_stencil, cdbus_reply_bool);
 	cdbus_m_opts_get_do(glx_no_rebind_pixmap, cdbus_reply_bool);
-	cdbus_m_opts_get_do(glx_swap_method, cdbus_reply_int32);
+	cdbus_m_opts_get_do(use_damage, cdbus_reply_bool);
 #endif
 
 	cdbus_m_opts_get_do(track_focus, cdbus_reply_bool);

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -53,11 +53,6 @@ bool glx_init(session_t *ps, bool need_render) {
 		}
 	}
 
-	if (ps->o.glx_swap_method > CGLX_MAX_BUFFER_AGE) {
-		log_error("glx-swap-method is too big");
-		goto glx_init_end;
-	}
-
 	// Get XVisualInfo
 	pvis = get_visualinfo_from_visual(ps, ps->vis);
 	if (!pvis) {


### PR DESCRIPTION
- [x] Change config_libconfig.c to print warning message for option
- [x] Change options.c to print warning message for option
- [x] Remove option variable from config.h
- [x] Remove old usage message from options.c
  - [x] If added a replacement, add new usage message
- [x] Remove usage info from man/compton.1.asciidoc
  - [x] If added a replacement, add new usage info
- [x] Remove the use of the deprecated option from compton.sample.conf
  - [x] If added a replacement, add new example