### PR TITLE
Add FreeBSD build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ $ meson --buildtype=release . build
 $ ninja -C build
 ```
 
+On FreeBSD, `ld` does not look by default in /usr/local/lib, and you will get errors about some libraries being not found.
+To fix that, append `LDFLAGS="-L/usr/local/lib"`:
+```bash
+$ LDFLAGS="-L/usr/local/lib" meson --buildtype=release . build
+$ ninja -C build
+```
+
 Built binary can be found in `build/src`
 
 ### To install


### PR DESCRIPTION
This PR adds instruction on how to build compton on FreeBSD.

On FreeBSD, `ld` does not look into `/usr/local/lib` by default, which leaded to meson complaining about libev not being found, although it being installed and available in /usr/local/lib. The solution was to add `LDFLAGS="-L/usr/local/lib"` to the meson build command, and it locates the lib. That way we get Compton to compile and run on FreeBSD!