### PR TITLE
win: track windows with a hash table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, meso
 * libGL (optional, disable with the `-Dopengl=false` meson configure flag)
 * libpcre (optional, disable with the `-Dregex=false` meson configure flag)
 * libev
+* uthash
 
 To build the documents, you need `asciidoc`
 

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,9 @@ if get_option('sanitize')
 	endif
 	add_global_arguments('-fsanitize='+','.join(sanitizers), language: 'c')
 	add_global_link_arguments('-fsanitize='+','.join(sanitizers), language: 'c')
+	if cc.has_argument('-fno-sanitize=unsigned-integer-overflow')
+		add_global_arguments('-fno-sanitize=unsigned-integer-overflow', language: 'c')
+	endif
 endif
 
 if get_option('modularize')

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,10 @@ foreach i : required_package
 	base_deps += [dependency(i, required: true)]
 endforeach
 
+if not cc.has_header('uthash.h')
+  error('Dependency uthash not found')
+endif
+
 deps = []
 
 if get_option('config_file')

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -26,6 +26,7 @@
 #include "string_utils.h"
 #include "utils.h"
 #include "win.h"
+#include "uthash_extra.h"
 
 #include "opengl.h"
 
@@ -220,8 +221,9 @@ void glx_destroy(session_t *ps) {
 		return;
 
 	// Free all GLX resources of windows
-	for (win *w = ps->list; w; w = w->next)
+	WIN_STACK_ITER(ps, w) {
 		free_win_res_glx(ps, w);
+	}
 
 	// Free GLSL shaders/programs
 	for (int i = 0; i < MAX_BLUR_PASS; ++i) {

--- a/src/uthash_extra.h
+++ b/src/uthash_extra.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <uthash.h>
+
+#define HASH_ITER2(head, el)                                                             \
+	for (__typeof__(head) el = (head), __tmp = el != NULL ? el->hh.next : NULL;      \
+	     el != NULL; el = __tmp, __tmp = el != NULL ? el->hh.next : NULL)

--- a/src/win.h
+++ b/src/win.h
@@ -7,19 +7,24 @@
 #include <xcb/render.h>
 #include <xcb/xcb.h>
 
+#include "uthash_extra.h"
+
 // FIXME shouldn't need this
 #ifdef CONFIG_OPENGL
 #include <GL/gl.h>
 #endif
 
+#include "backend/backend.h"
 #include "c2.h"
 #include "compiler.h"
 #include "region.h"
 #include "render.h"
 #include "types.h"
 #include "utils.h"
-#include "backend/backend.h"
 #include "x.h"
+
+#define WIN_STACK_ITER(ps, w)                                                            \
+	for (win *w = ps->window_stack, *next; w ? (next = w->next, true) : false; w = next)
 
 typedef struct session session_t;
 typedef struct _glx_texture glx_texture_t;
@@ -285,6 +290,7 @@ struct win {
 	/// Textures and FBO background blur use.
 	glx_blur_cache_t glx_blur_cache;
 #endif
+	UT_hash_handle hh;
 };
 
 void win_release_image(backend_t *base, win *w);
@@ -392,6 +398,8 @@ void win_ev_stop(session_t *ps, const win *w);
 /// Skip the current in progress fading of window,
 /// transition the window straight to its end state
 void win_skip_fading(session_t *ps, win **_w);
+win *find_win(session_t *ps, xcb_window_t id);
+win *find_toplevel(session_t *ps, xcb_window_t id);
 
 /**
  * Get the leader of a window.

--- a/src/win.h
+++ b/src/win.h
@@ -137,6 +137,8 @@ struct win {
 	void *shadow_image;
 	/// Pointer to the next lower window in window stack.
 	win *next;
+	/// Pointer to a linked-list pointer that points to this window.
+	win **prev;
 	/// Pointer to the next higher window to paint.
 	win *prev_trans;
 	// TODO rethink reg_ignore


### PR DESCRIPTION
Known problem: ID collision when a new window is created with the same
window ID as a destroyed window which is being faded out.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>