### PR TITLE
rewrite FreeBSD instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ $ meson --buildtype=release . build
 $ ninja -C build
 ```
 
-On FreeBSD, `ld` does not look by default in /usr/local/lib, and you will get errors about some libraries being not found.
-To fix that, prepend `LDFLAGS="-L/usr/local/lib"`:
+##### FreeBSD
+To help meson find libraries and headers under FreeBSD:
 ```bash
-$ LDFLAGS="-L/usr/local/lib" meson --buildtype=release . build
+$ CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib meson --buildtype=release . build
 $ ninja -C build
 ```
 


### PR DESCRIPTION
This PR rewrites the build instructions for FreeBSD.
As now Compton depends on uthash, and FreeBSD installs the header to /usr/local/include, meson does not find it. For now, the fix is to prepend CPPFLAGS=-I/usr/local/include

I based the command on lighttpd's [README.FreeBSD](https://redmine.lighttpd.net/projects/lighttpd/repository/revisions/master/entry/README.FreeBSD#L48)