### PR TITLE
For some reason NVIDIA drivers do not re-enable vsync once disabled

### DIFF
--- a/src/vsync.c
+++ b/src/vsync.c
@@ -151,7 +151,7 @@ static int vsync_opengl_oml_wait(session_t *ps) {
  */
 bool vsync_init(session_t *ps) {
 #ifdef CONFIG_OPENGL
-	if (bkend_use_glx(ps)) {
+	if (bkend_use_glx(ps) && !(ps->drivers & DRIVER_NVIDIA)) {
 		// Mesa turns on swap control by default, undo that
 		vsync_opengl_swc_swap_interval(ps, 0);
 	}


### PR DESCRIPTION
It seems if vsync is disabled at beginning of vsync_init() it is not enabled later (no error messages, etc) with "vsync = true" I guess compton thinks everything is OK, but glxgears runs ~1000FPS with noticable CPU usage.

After disable initia vsync for NV everything sees to work just fine. I got smooth 60FPS with almost no CPU used.

Tested on Precision 5510 with 430.14 on Quadro M1000M