### PR TITLE
build: install scripts into bindir provided by meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,8 @@ test_h_dep = subproject('test.h').get_variable('test_h_dep')
 subdir('src')
 subdir('man')
 
-install_subdir('bin', install_dir: '')
+install_data(['bin/compton-convgen.py', 'bin/compton-trans'],
+             install_dir: get_option('bindir'))
 install_data('compton.desktop', install_dir: 'share/applications')
 install_data('media/icons/48x48/compton.png',
              install_dir: 'share/icons/hicolor/48x48/apps')


### PR DESCRIPTION
This will use --bindir value to install additional scripts into the same location
as compton binary (current behavior: hardcoded $prefix/bin).
Useful for custom installations and/or cross-compiling.