### PR TITLE
stable/7: remove meson dependency on unittests

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -77,7 +77,7 @@ endif
 subdir('backend')
 
 compton = executable('compton', srcs, c_args: cflags,
-  dependencies: [ base_deps, deps, test_h_dep ],
+  dependencies: [ base_deps, deps ],
   install: true, include_directories: compton_inc)
 
 if get_option('unittest')


### PR DESCRIPTION
Right now the `meson build` for compton-7 fails because meson tries to build the test subproject which is not included in the release tarball.

This removes the dependency on that in stable/7.

Probably needs a change to `make-release.sh` in next as well to catch this for the next release.