### PR TITLE
added keywords to desktop entry

### DIFF
--- a/compton.desktop
+++ b/compton.desktop
@@ -5,6 +5,7 @@ Name=compton
 GenericName=X compositor
 Comment=A X compositor
 Categories=Utility;
+Keywords=compositor;composite manager;window effects;transparency;opacity;
 TryExec=compton
 Exec=compton
 Icon=compton


### PR DESCRIPTION
Among other benefits, this will make [Lintian happy](https://lintian.debian.org/tags/desktop-entry-lacks-keywords-entry.html). The justification for this, is among other reasons, [searchability](https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords). Not to mention it just doesn't hurt.