### PR TITLE
Unbreak build without OpenGL

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -14,7 +14,9 @@
 #include <xcb/xfixes.h>
 
 #include "atom.h"
+#ifdef CONFIG_OPENGL
 #include "backend/gl/glx.h"
+#endif
 #include "common.h"
 #include "compiler.h"
 #include "kernel.h"


### PR DESCRIPTION
See [error log](https://github.com/yshui/compton/files/3720715/compton-n.100.1.log)
