### PR TITLE
Add time uniform to glsl shaders

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -107,10 +107,15 @@ typedef struct glx_prog_main {
 	GLint unifm_invert_color;
 	/// Location of uniform "tex" in window GLSL program.
 	GLint unifm_tex;
+	/// Location of uniform "time" in window GLSL program.
+	GLint unifm_time;
 } glx_prog_main_t;
 
 #define GLX_PROG_MAIN_INIT                                                               \
-	{ .prog = 0, .unifm_opacity = -1, .unifm_invert_color = -1, .unifm_tex = -1, }
+	{                                                                                \
+		.prog = 0, .unifm_opacity = -1, .unifm_invert_color = -1,                \
+		.unifm_tex = -1, .unifm_time = -1                                        \
+	}
 
 #else
 struct glx_prog_main {};

--- a/src/common.h
+++ b/src/common.h
@@ -107,10 +107,12 @@ typedef struct glx_prog_main {
 	GLint unifm_invert_color;
 	/// Location of uniform "tex" in window GLSL program.
 	GLint unifm_tex;
+	/// Location of uniform "time" in window GLSL program.
+	GLint unifm_time;
 } glx_prog_main_t;
 
 #define GLX_PROG_MAIN_INIT                                                               \
-	{ .prog = 0, .unifm_opacity = -1, .unifm_invert_color = -1, .unifm_tex = -1, }
+	{ .prog = 0, .unifm_opacity = -1, .unifm_invert_color = -1, .unifm_tex = -1, .unifm_time = -1}
 
 #else
 struct glx_prog_main {};

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <xcb/render.h>
 #include <xcb/xcb.h>
 
@@ -442,6 +443,7 @@ bool glx_load_prog_main(const char *vshader_str, const char *fshader_str,
 	P_GET_UNIFM_LOC("opacity", unifm_opacity);
 	P_GET_UNIFM_LOC("invert_color", unifm_invert_color);
 	P_GET_UNIFM_LOC("tex", unifm_tex);
+	P_GET_UNIFM_LOC("time", unifm_time);
 #undef P_GET_UNIFM_LOC
 
 	gl_check_err();
@@ -1029,12 +1031,16 @@ bool glx_render(session_t *ps, const glx_texture_t *ptex, int x, int y, int dx, 
 		// Programmable path
 		assert(pprogram->prog);
 		glUseProgram(pprogram->prog);
+                struct timespec ts;
+                clock_gettime(CLOCK_MONOTONIC, &ts);
 		if (pprogram->unifm_opacity >= 0)
 			glUniform1f(pprogram->unifm_opacity, (float)opacity);
 		if (pprogram->unifm_invert_color >= 0)
 			glUniform1i(pprogram->unifm_invert_color, neg);
 		if (pprogram->unifm_tex >= 0)
 			glUniform1i(pprogram->unifm_tex, 0);
+                if (pprogram->unifm_time >= 0)
+                        glUniform1i(pprogram->unifm_time, ts.tv_sec * 1000 + ts.tv_nsec / 1.0e6);
 	}
 
 	// log_trace("Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d", x, y, width, height,

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <xcb/render.h>
 #include <xcb/xcb.h>
 
@@ -442,6 +443,7 @@ bool glx_load_prog_main(const char *vshader_str, const char *fshader_str,
 	P_GET_UNIFM_LOC("opacity", unifm_opacity);
 	P_GET_UNIFM_LOC("invert_color", unifm_invert_color);
 	P_GET_UNIFM_LOC("tex", unifm_tex);
+	P_GET_UNIFM_LOC("time", unifm_time);
 #undef P_GET_UNIFM_LOC
 
 	gl_check_err();
@@ -1029,12 +1031,16 @@ bool glx_render(session_t *ps, const glx_texture_t *ptex, int x, int y, int dx, 
 		// Programmable path
 		assert(pprogram->prog);
 		glUseProgram(pprogram->prog);
+		struct timespec ts;
+		clock_gettime(CLOCK_MONOTONIC, &ts);
 		if (pprogram->unifm_opacity >= 0)
 			glUniform1f(pprogram->unifm_opacity, (float)opacity);
 		if (pprogram->unifm_invert_color >= 0)
 			glUniform1i(pprogram->unifm_invert_color, neg);
 		if (pprogram->unifm_tex >= 0)
 			glUniform1i(pprogram->unifm_tex, 0);
+		if (pprogram->unifm_time >= 0)
+			glUniform1i(pprogram->unifm_time, ts.tv_sec * 1000 + ts.tv_nsec / 1.0e6);
 	}
 
 	// log_trace("Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d", x, y, width, height,


### PR DESCRIPTION
Added an updating uniform that can be used to animate GLSL shaders. As discussed in https://github.com/yshui/picom/issues/295

After looking at the different options available already in picom I was able to have a pretty limited changeset to get the effect I wanted. If you want to test it you can use this shader I wrote:

```
uniform float opacity;
uniform bool invert_color;
uniform sampler2D tex;
uniform float time;

float amt = 2000.0;

void main() {
        float pct = mod(time, amt)/amt;
        vec2 pos = gl_TexCoord[0].st;
        vec4 c = texture2D(tex, pos);
        float a = pos.x + pos.y;
        if (a < pct * 4.0 && a > pct * 4.0 - 0.5 * pct)
           c *= vec4(2, 2, 2, 1);
        else if (a < pct * 4.0 - 0.8 * pct && a > pct * 3.0)
           c *= vec4(2, 2, 2, 1);
        if (invert_color)
           c = vec4(vec3(c.a, c.a, c.a) - vec3(c), c.a);
        c *= opacity;
        gl_FragColor = c;
}
```

Then run picom with these changes and the following flags (This assumes you have the previous shader saved to `~/shine.glsl`):

`picom --sw-opti --benchmark 100000 --no-use-damage --backend glx --glx-fshader-win "$(cat ~/shine.glsl)"`

It should look something like this:

https://streamable.com/e0x7r

Some issues:

- Using benchmark is obviously really hacky. Changes from the shader won't queue a redraw, so we can't wait on draw_idle to be enabled. Either these changes would need to affect draw_idle or there would need to be a nicer way to ignore it.
- Similarly I have to ignore damage as changes from the shader are ignored. Not being idle can really tear up performance and finding a solution is probably necessary. Luckily --sw-opti cuts the cost significantly for me, but it doesn't fix everything.

I really think with a few more options you could do some pretty powerful stuff, but it might be out of the scope of this pull request. Some basic stuff that comes to mind:

- Timer since window was created
- Timer since window was focused/last focused
- Window dimensions
- And the numerous other values that a window can have (class, name, etc.)