### PR TITLE
[RFC] Custom window shader in experimental OpenGL backend

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -328,6 +328,11 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 
 		// Draw window on target
 		if (!w->invert_color && !w->dim && w->frame_opacity == 1 && w->opacity == 1) {
+			if (w->fg_shader) {
+				ps->backend_data->ops->image_op(
+				    ps->backend_data, IMAGE_OP_SET_SHADER, w->win_image,
+				    NULL, NULL, (void *)w->fg_shader);
+			}
 			ps->backend_data->ops->compose(ps->backend_data, w->win_image,
 			                               w->g.x, w->g.y,
 			                               &reg_paint_in_bound, &reg_visible);
@@ -387,6 +392,11 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 				ps->backend_data->ops->image_op(
 				    ps->backend_data, IMAGE_OP_APPLY_ALPHA_ALL, new_img,
 				    NULL, &reg_visible_local, (double[]){w->opacity});
+			}
+			if (w->fg_shader) {
+				ps->backend_data->ops->image_op(
+				    ps->backend_data, IMAGE_OP_SET_SHADER, new_img, NULL,
+				    NULL, (void *)w->fg_shader);
 			}
 			ps->backend_data->ops->compose(ps->backend_data, new_img, w->g.x,
 			                               w->g.y, &reg_paint_in_bound,

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -49,6 +49,8 @@ enum image_operations {
 	IMAGE_OP_RESIZE_TILE,
 	// Limit how bright image can be
 	IMAGE_OP_MAX_BRIGHTNESS,
+	// Set the shader program to use
+	IMAGE_OP_SET_SHADER,
 };
 
 struct gaussian_blur_args {

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <xcb/render.h>        // for xcb_render_fixed_t, XXX
 
 #include "backend/backend.h"
@@ -408,6 +409,12 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 	}
 	if (win_shader->unifm_max_brightness >= 0) {
 		glUniform1f(win_shader->unifm_max_brightness, (float)img->max_brightness);
+	}
+	if (win_shader->unifm_time >= 0) {
+		struct timespec ts;
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		glUniform1f(win_shader->unifm_time,
+		            (float)ts.tv_sec * 1000.0f + (float)ts.tv_nsec / 1.0e6f);
 	}
 
 	// log_trace("Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d\n",
@@ -936,6 +943,7 @@ static bool gl_win_shader_from_stringv(const char **vshader_strv,
 	ret->unifm_brightness = glGetUniformLocationChecked(ret->prog, "brightness");
 	ret->unifm_max_brightness =
 	    glGetUniformLocationChecked(ret->prog, "max_brightness");
+	ret->unifm_time = glGetUniformLocationChecked(ret->prog, "time");
 
 	glUseProgram(ret->prog);
 	int orig_loc = glGetUniformLocation(ret->prog, "orig");

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -15,6 +15,8 @@
 
 // Program and uniforms for window shader
 typedef struct {
+	UT_hash_handle hh;
+	uint32_t id;
 	GLuint prog;
 	GLint unifm_opacity;
 	GLint unifm_invert_color;
@@ -58,6 +60,7 @@ struct gl_texture {
 /// @brief Wrapper of a binded GLX texture.
 typedef struct gl_image {
 	struct gl_texture *inner;
+	gl_win_shader_t *shader;
 	double opacity;
 	double dim;
 	double max_brightness;
@@ -72,7 +75,8 @@ struct gl_data {
 	bool is_nvidia;
 	// Height and width of the root window
 	int height, width;
-	gl_win_shader_t win_shader;
+	// Hash-table of window shaders
+	gl_win_shader_t *win_shaders;
 	gl_brightness_shader_t brightness_shader;
 	gl_fill_shader_t fill_shader;
 	GLuint back_texture, back_fbo;
@@ -100,8 +104,8 @@ GLuint gl_create_program_from_str(const char *vert_shader_str, const char *frag_
 /**
  * @brief Render a region with texture data.
  */
-void gl_compose(backend_t *, void *ptex, int dst_x, int dst_y, const region_t *reg_tgt,
-                const region_t *reg_visible);
+void gl_compose(backend_t *, void *image_data, int dst_x, int dst_y,
+                const region_t *reg_tgt, const region_t *reg_visible);
 
 void gl_resize(struct gl_data *, int width, int height);
 

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -24,6 +24,7 @@ typedef struct {
 	GLint unifm_dim;
 	GLint unifm_brightness;
 	GLint unifm_max_brightness;
+	GLint unifm_time;
 } gl_win_shader_t;
 
 // Program and uniforms for brightness shader

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -465,6 +465,7 @@ static bool image_op(backend_t *base, enum image_operations op, void *image,
 		break;
 	case IMAGE_OP_APPLY_ALPHA_ALL: assert(false);
 	case IMAGE_OP_MAX_BRIGHTNESS: assert(false);
+	case IMAGE_OP_SET_SHADER: assert(false);
 	}
 	pixman_region32_fini(&reg);
 	return true;

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,8 @@
 #include <xcb/xcb.h>
 #include <xcb/xfixes.h>
 
+#include "uthash_extra.h"
+
 #ifdef CONFIG_LIBCONFIG
 #include <libconfig.h>
 #endif
@@ -64,6 +66,24 @@ enum blur_method {
 	BLUR_METHOD_GAUSSIAN,
 	BLUR_METHOD_DUAL_KAWASE,
 	BLUR_METHOD_INVALID,
+};
+
+enum custom_shader_id {
+	CUSTOM_SHADER_DEFAULT = 0,
+	CUSTOM_SHADER_CUSTOM_START,
+};
+struct custom_shader {
+	UT_hash_handle hh;
+	uint32_t id;
+	char *path;
+	char *source;
+};
+
+static const struct custom_shader custom_shader_default = {
+    .hh = {0},
+    .id = CUSTOM_SHADER_DEFAULT,
+    .path = "DEFAULT",
+    .source = NULL,
 };
 
 typedef struct _c2_lptr c2_lptr_t;
@@ -206,6 +226,12 @@ typedef struct options {
 	struct conv **blur_kerns;
 	/// Number of convolution kernels
 	int blur_kernel_count;
+	/// Hash table of custom fragment shaders
+	struct custom_shader *custom_shaders;
+	/// Custom fragment shader for painting windows
+	const struct custom_shader *window_shader_fg;
+	/// Rules to change custom fragment shader for painting windows.
+	c2_lptr_t *window_shader_fg_rules;
 	/// How much to dim an inactive window. 0.0 - 1.0, 0 to disable.
 	double inactive_dim;
 	/// Whether to use fixed inactive dim opacity, instead of deciding
@@ -251,6 +277,10 @@ bool must_use parse_int(const char *, int *);
 struct conv **must_use parse_blur_kern_lst(const char *, bool *hasneg, int *count);
 bool must_use parse_geometry(session_t *, const char *, region_t *);
 bool must_use parse_rule_opacity(c2_lptr_t **, const char *);
+const struct custom_shader *must_use parse_custom_shader(const char *, struct custom_shader **,
+                                                         const char *);
+bool must_use parse_rule_window_shader(c2_lptr_t **, struct custom_shader **,
+                                       const char *, const char *);
 enum blur_method must_use parse_blur_method(const char *src);
 
 /**
@@ -259,6 +289,9 @@ enum blur_method must_use parse_blur_method(const char *src);
 bool condlst_add(c2_lptr_t **, const char *);
 
 #ifdef CONFIG_LIBCONFIG
+const char *xdg_config_home(void);
+char **xdg_config_dirs(void);
+
 /// Parse a configuration file
 /// Returns the actually config_file name used, allocated on heap
 /// Outputs:

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -9,7 +9,6 @@
 #define mstrncmp(s1, s2) strncmp((s1), (s2), strlen(s1))
 
 char *mstrjoin(const char *src1, const char *src2);
-char *mstrjoin3(const char *src1, const char *src2, const char *src3);
 void mstrextend(char **psrc1, const char *src2);
 
 /// Parse a floating point number of form (+|-)?[0-9]*(\.[0-9]*)

--- a/src/win.h
+++ b/src/win.h
@@ -254,6 +254,9 @@ struct managed_win {
 	/// Whether to blur window background.
 	bool blur_background;
 
+	/// The custom window shader to use when rendering.
+	const struct custom_shader *fg_shader;
+
 #ifdef CONFIG_OPENGL
 	/// Textures and FBO background blur use.
 	glx_blur_cache_t glx_blur_cache;


### PR DESCRIPTION
Implementation of an advanced interface for custom window shaders in the new experimental OpenGL backend (see https://github.com/yshui/picom/issues/386). This will offer similar functionality to the existing `glx-fshader-win` option in the legacy backend but should be easier to use and cover more use-cases.

**WARNING: This is currently just a Proof-of-Concept to gather some feedback on the interface.**
**This has known bugs and will likely crash with an improper config as some checks are still missing.**

### Implementation details

*The implementation is up for debate. Comments and ideas for improvements welcome!*

#### Configuration

Custom (foreground) window shaders can be supplied with the `window-shader-fg` option.
Supported values are either:
- "default" for the built-in default (just get the pixel)
- ~~inline shader source in single quotes (`'`)~~
- filename to a fragment shader, either absolute path or relative to the current directory (`PWD` when on cli, config file else) / in folder `picom/shaders/` similar to the config-file search paths

The supplied shader must be a glsl fragment shader and at least consist of the function `vec4 window_shader()` which should return the current pixel for further processing (inversion, alpha-baking, brightness-clamping).

Window specific shaders can be specified with the `window-shader-fg-rule` option, similar to how `opacity-rule` works. Each entry is one of the supported values from `window-shader-fg` separated with a colon (`:`) from a window rule.
This currently comes with the limitation that the filename and inline source must not contain a colon.

Example configuration to desaturate unfocused windows:
```
#window-shader-fg = "default";
#window_shader-fg ="/etc/picom/shaders/testing/default.frag";
window-shader-fg-rule = [
    "desaturate.frag:focused != 1 && window_type = 'normal'",
]
```
And a file `desaturate.frag` next to the configuration file:
```glsl
#version 330
in vec2 texcoord;
uniform sampler2D tex;

vec4 window_shader() {
    vec4 pixel = texelFetch(tex, ivec2(texcoord), 0);
    return vec4(vec3(dot(vec3(0.2126, 0.7152, 0.0722), pixel.rgb)), pixel.a);
}
```

#### Rendering Pipeline

Each specified shader is saved in a hash-map with a unique id. Each managed window has a reference to the configured shader in this hash-map and is updated with the reference of a window rule if specified. Else the configured default (`window-shader-fg`) or a fallback is used.
A hash-map is used to prevent loading the same shader multiple times and generating multiple programs for the same shader.

The OpenGL backend initializes programs for each shader in a new hash-map based on the shaders unique id. The `gl_image` struct keeps a reference to one entry in the program hash-map. The referenced program is used in `_gl_compose()` to render the image to screen.

The backend is extended with a new *image operation* `IMAGE_OP_SET_SHADER`. This is called on the image before `compose()` when the window uses a custom shader and should not be called on backends that do not support custom shaders (currently only the `gl` backend has support). The correct program is then selected from the hash-map (via id) and referenced in the image.

### Discussion of new features

- Additional step in the rendering pipeline analogous to blurring with `window-shader-bg`. Render the background blur to a temporary texture and call a custom user-supplied shader on this and the original background. This may allow custom effects behind transparent windows or other deformations with background blur.

- Support for multiple shaders per rule by allowing multiple "shader objects" to be passed. This would allow modularized shaders for advanced use cases (common filters in separate files, custom composition for different rules, i.e. a separate color-key filter with different constants for different windows). This could probably be done by allowing multiple values separated by semi-colons (`;`) in the relevant config-options.

- The configuration options could be made more robust by explicitly stating `default()`, ~~`inline('#version 333…')`,~~ and `file('shader.frag')`.

- Additional uniforms that might be useful:
    - Time/Counter for animations (currently implemented for `glx-fshader-win`)
    - Window position and window/texture size for custom scaling or translation
    - Access to the background texture?

- Should there be an option to use a completely custom shader and bypass the current pipeline completely?
We currently depend on alpha-baking in the window shader. Color-inversion and brightness-clamping are features specified via user configuration. When we completely replace the window shader, the user must make sure to re-implement these features or else these options would loose their effect.

### Todo

- [ ] Feature parity with existing `glx-fshader-win`
    - [x] Add the `time` uniform for animations
    - [x] Parse `window-shader-fg` option on the commandline
- [x] Correctly protect against use on unsupported backends
- [x] Load shader from file
- [ ] Implement new uniforms
- [ ] Add documentation to the manpage
- [ ] Support for multiple shaders / files
- [ ] Custom shaders for background rendering (after blur)
