### PR TITLE
fix log_debug call

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -539,8 +539,8 @@ static bool initialize_backend(session_t *ps) {
 				} else {
 					shader->attributes = 0;
 				}
-				log_debug("Shader %s has attributes %ld", shader->key,
-				          shader->attributes);
+				log_debug("Shader %s has attributes %" PRIu64,
+				          shader->key, shader->attributes);
 			}
 		}
 


### PR DESCRIPTION
Use proper printf directive for `uint64_t` because it's not guaranteed to be `long`.  On OpenBSD/amd64 it's `long long` for example.