### PR TITLE
undefined symbol: glEGLImageTargetTexStorageEXT

### DIFF
--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -36,6 +36,8 @@ struct egl_data {
 	EGLContext ctx;
 };
 
+static PFNGLEGLIMAGETARGETTEXSTORAGEEXTPROC glEGLImageTargetTexStorage = NULL;
+
 /**
  * Free a glx_texture_t.
  */
@@ -202,6 +204,14 @@ static backend_t *egl_init(session_t *ps) {
 		goto end;
 	}
 
+	glEGLImageTargetTexStorage =
+	    (PFNGLEGLIMAGETARGETTEXSTORAGEEXTPROC)eglGetProcAddress("glEGLImageTargetTexS"
+	                                                            "torageEXT");
+	if (glEGLImageTargetTexStorage == NULL) {
+		log_error("Failed to get glEGLImageTargetTexStorageEXT.");
+		goto end;
+	}
+
 	gd->gl.decouple_texture_user_data = egl_decouple_user_data;
 	gd->gl.release_user_data = egl_release_image;
 
@@ -270,7 +280,7 @@ egl_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, b
 	wd->dim = 0;
 	wd->inner->refcount = 1;
 	glBindTexture(GL_TEXTURE_2D, inner->texture);
-	glEGLImageTargetTexStorageEXT(GL_TEXTURE_2D, eglpixmap->image, NULL);
+	glEGLImageTargetTexStorage(GL_TEXTURE_2D, eglpixmap->image, NULL);
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	gl_check_err();


### PR DESCRIPTION
Hello,

picom fails to build on OpenBSD due to a linker error:

```
ld: error: undefined symbol: glEGLImageTargetTexStorageEXT
>>> referenced by egl.c:273 (../src/backend/gl/egl.c:273)
>>>               src/picom.p/backend_gl_egl.c.o:(egl_bind_pixmap)
```

The compiler doesn't report any warning while compiling, but the linking faills.  There's a prototype for `glEGLImageTargetTexStorageEXT`, but I guess the function pointer needs to be retrieved via `eglGetProcAddress`?  I'm not sure.  I don't have any prior experience with opengl, mesa or X11 rendering in general, so please review this diff with extra care.

I've come up with this diff that at least allows to build and seems to work.  I'm running `picom --config /dev/null --vsync --backend egl`.

Note that it's lacking a cast on the return of `eglGetProcAddress`, and I'm not sure I'm using `eglGetProcAddress` in an idiomatic way.

Thanks!