### PR TITLE
c2: replace pcre with pcre2

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -44,11 +44,8 @@ if get_option('config_file')
 	srcs += [ 'config_libconfig.c' ]
 endif
 if get_option('regex')
-	pcre = dependency('libpcre', required: true)
+	pcre = dependency('libpcre2-8', required: true)
 	cflags += ['-DCONFIG_REGEX_PCRE']
-	if pcre.version().version_compare('>=8.20')
-		cflags += ['-DCONFIG_REGEX_PCRE_JIT']
-	endif
 	deps += [pcre]
 endif
 


### PR DESCRIPTION
Because pcre has been deprecated.[1]

There are subtle changes from pcre to pcre2, so this could be a breaking change.

Closes #895

[1]: https://www.pcre.org/original/changelog.txt

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
