### PR TITLE
Consider borders when creating the mask image

### DIFF
--- a/src/win.c
+++ b/src/win.c
@@ -350,7 +350,7 @@ bool win_bind_mask(struct backend_base *b, struct managed_win *w) {
 	auto reg_bound_local = win_get_bounding_shape_global_by_val(w);
 	pixman_region32_translate(&reg_bound_local, -w->g.x, -w->g.y);
 	w->mask_image = b->ops->make_mask(
-	    b, (geometry_t){.width = w->g.width, .height = w->g.height}, &reg_bound_local);
+	    b, (geometry_t){.width = w->widthb, .height = w->heightb}, &reg_bound_local);
 	pixman_region32_fini(&reg_bound_local);
 
 	if (!w->mask_image) {


### PR DESCRIPTION
With rounded corners, X11 native border and blur enabled,
left and bottom 2*border_width pixels were not blurred, 
since mask did not include border_width, only content width and height.

Create mask image with dimensions that include border width.

I hope the fix is correct, since I am not that familiar with the codebase.
At least for me it works fine for all of the new backends.

An image, demonstrating the issue with overly large borders and corner radius:
![image](https://user-images.githubusercontent.com/12730177/204864967-1bcf3493-b00d-4c9a-bdce-6dc19afd4b61.png)