### PR TITLE
README: fix meson's warnings about setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build the documents, you need `asciidoc`
 
 ```bash
 $ git submodule update --init --recursive
-$ meson --buildtype=release . build
+$ meson setup --buildtype=release . build
 $ ninja -C build
 ```
 
@@ -70,13 +70,12 @@ If you have libraries and/or headers installed at non-default location (e.g. und
 You can do that by setting the `CPPFLAGS` and `LDFLAGS` environment variables when running `meson`. Like this:
 
 ```bash
-$ LDFLAGS="-L/path/to/libraries" CPPFLAGS="-I/path/to/headers" meson --buildtype=release . build
-
+$ LDFLAGS="-L/path/to/libraries" CPPFLAGS="-I/path/to/headers" meson setup --buildtype=release . build
 ```
 
 As an example, on FreeBSD, you might have to run meson with:
 ```bash
-$ LDFLAGS="-L/usr/local/lib" CPPFLAGS="-I/usr/local/include" meson --buildtype=release . build
+$ LDFLAGS="-L/usr/local/lib" CPPFLAGS="-I/usr/local/include" meson setup --buildtype=release . build
 $ ninja -C build
 ```
 


### PR DESCRIPTION
this fixes ``WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.`` warning while setting up the project