### PR TITLE
core: detect screen off

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     # Install dependencies
-    - run: sudo apt update && sudo apt install libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libxcb-glx0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl1-mesa-dev  libpcre2-dev  libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson ninja-build
+    - run: sudo apt update && sudo apt install libxext-dev libxcb1-dev libxcb-dpms0-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libxcb-glx0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl1-mesa-dev  libpcre2-dev  libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson ninja-build
       if: ${{ matrix.language == 'cpp' }}
 
     # Autobuild

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 * xproto
 * xcb
 * xcb-damage
+* xcb-dpms
 * xcb-xfixes
 * xcb-shape
 * xcb-renderutil
@@ -44,7 +45,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 On Debian based distributions (e.g. Ubuntu), the needed packages are
 
 ```
-libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libxcb-glx0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl-dev libegl-dev libpcre2-dev libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson
+libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-dpms0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libxcb-glx0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl-dev libegl-dev libpcre2-dev libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson
 ```
 
 On Fedora, the needed packages are

--- a/src/common.h
+++ b/src/common.h
@@ -150,6 +150,8 @@ typedef struct session {
 	// === Event handlers ===
 	/// ev_io for X connection
 	ev_io xiow;
+	/// Timer for checking DPMS power level
+	ev_timer dpms_check_timer;
 	/// Timeout for delayed unredirection.
 	ev_timer unredir_timer;
 	/// Timer for fading
@@ -236,6 +238,8 @@ typedef struct session {
 	xcb_sync_fence_t sync_fence;
 	/// Whether we are rendering the first frame after screen is redirected
 	bool first_frame;
+	/// Whether screen has been turned off
+	bool screen_is_off;
 
 	// === Operation related ===
 	/// Flags related to the root window
@@ -342,6 +346,8 @@ typedef struct session {
 	int composite_error;
 	/// Major opcode for X Composite extension.
 	int composite_opcode;
+	/// Whether X DPMS extension exists
+	bool dpms_exists;
 	/// Whether X Shape extension exists.
 	bool shape_exists;
 	/// Event base number for X Shape extension.

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,8 @@ cflags = []
 
 required_xcb_packages = [
 	'xcb-render', 'xcb-damage', 'xcb-randr', 'xcb-sync', 'xcb-composite',
-	'xcb-shape', 'xcb-xinerama', 'xcb-xfixes', 'xcb-present', 'xcb-glx', 'xcb'
+	'xcb-shape', 'xcb-xinerama', 'xcb-xfixes', 'xcb-present', 'xcb-glx', 
+	'xcb-dpms', 'xcb'
 ]
 
 required_packages = [


### PR DESCRIPTION
Use the DPMS extension to detect if screen is turned off, and unredirect if it is. This also helps working around the problem where OpenGL buffers lose data when screen is turned off, causing screen to flicker later when it turns back on if use-damage is enabled.

Unfortunately the DPMS extension doesn't define an event, so we have to periodically poll the screen state.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
