### PR TITLE
xrender: fix leak in release_rounded_corner_cache

### DIFF
--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -554,7 +554,7 @@ release_rounded_corner_cache(backend_t *base, struct xrender_rounded_rectangle_c
 	assert(cache->refcount > 0);
 	cache->refcount--;
 	if (cache->refcount == 0) {
-		xcb_free_pixmap(base->c, cache->p);
+		xcb_render_free_picture(base->c, cache->p);
 		free(cache);
 	}
 }


### PR DESCRIPTION
calling wrong free function did nothing and produced ton of x errors

fixes at least #892

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
