### PR TITLE
xrender: make corner-radius respect inactive-dim

### DIFF
--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -265,13 +265,6 @@ compose_impl(struct _xrender_data *xd, struct xrender_image *xrimg, coord_t dst,
 		xcb_render_composite(xd->base.c, XCB_RENDER_PICT_OP_SRC, inner->pict,
 		                     XCB_NONE, tmp_pict, 0, 0, 0, 0, 0, 0, tmpw, tmph);
 
-		if (img->corner_radius != 0 && xrimg->rounded_rectangle != NULL) {
-			// Clip tmp_pict with a rounded rectangle
-			xcb_render_composite(xd->base.c, XCB_RENDER_PICT_OP_IN_REVERSE,
-			                     xrimg->rounded_rectangle->p, XCB_NONE,
-			                     tmp_pict, 0, 0, 0, 0, 0, 0, tmpw, tmph);
-		}
-
 		if (img->color_inverted) {
 			if (inner->has_alpha) {
 				auto tmp_pict2 = x_create_picture_with_visual(
@@ -294,6 +287,7 @@ compose_impl(struct _xrender_data *xd, struct xrender_image *xrimg, coord_t dst,
 				                     0, 0, 0, 0, 0, 0, tmpw, tmph);
 			}
 		}
+
 		if (img->dim != 0) {
 			// Dim the actually content of window
 			xcb_rectangle_t rect = {
@@ -305,6 +299,13 @@ compose_impl(struct _xrender_data *xd, struct xrender_image *xrimg, coord_t dst,
 
 			xcb_render_fill_rectangles(xd->base.c, XCB_RENDER_PICT_OP_OVER,
 			                           tmp_pict, dim_color, 1, &rect);
+		}
+
+		if (img->corner_radius != 0 && xrimg->rounded_rectangle != NULL) {
+			// Clip tmp_pict with a rounded rectangle
+			xcb_render_composite(xd->base.c, XCB_RENDER_PICT_OP_IN_REVERSE,
+			                     xrimg->rounded_rectangle->p, XCB_NONE,
+			                     tmp_pict, 0, 0, 0, 0, 0, 0, tmpw, tmph);
 		}
 
 		xcb_render_composite(xd->base.c, XCB_RENDER_PICT_OP_OVER, tmp_pict,


### PR DESCRIPTION
for the new xrender backend it's enough to clip with a rounded rectangle after dimming, not before

partially fixes #867

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->

partially because the old xrender backend's corner-radius still doesn't respect inactive-dim. quick look at it makes me doubt that fixing it worths the effort. but this is still better than nothing, isn't it?