### PR TITLE
fix binding the root background pixmap in case of depth mismatch

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -321,6 +321,21 @@ xcb_visualid_t x_get_visual_for_standard(struct x_connection *c, xcb_pict_standa
 	return x_get_visual_for_pictfmt(g_pictfmts, pictfmt->id);
 }
 
+xcb_visualid_t x_get_visual_for_depth(struct x_connection *c, uint8_t depth) {
+	xcb_screen_iterator_t screen_it = xcb_setup_roots_iterator(xcb_get_setup(c->c));
+	for (; screen_it.rem; xcb_screen_next(&screen_it)) {
+		xcb_depth_iterator_t depth_it =
+		    xcb_screen_allowed_depths_iterator(screen_it.data);
+		for (; depth_it.rem; xcb_depth_next(&depth_it)) {
+			if (depth_it.data->depth == depth) {
+				return xcb_depth_visuals_iterator(depth_it.data).data->visual_id;
+			}
+		}
+	}
+
+	return XCB_NONE;
+}
+
 xcb_render_pictformat_t
 x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std) {
 	x_get_server_pictfmts(c);

--- a/src/x.c
+++ b/src/x.c
@@ -704,27 +704,6 @@ xcb_pixmap_t x_create_pixmap(struct x_connection *c, uint8_t depth, int width, i
 	return XCB_NONE;
 }
 
-/**
- * Validate a pixmap.
- *
- * Detect whether the pixmap is valid with XGetGeometry. Well, maybe there
- * are better ways.
- */
-bool x_validate_pixmap(struct x_connection *c, xcb_pixmap_t pixmap) {
-	if (pixmap == XCB_NONE) {
-		return false;
-	}
-
-	auto r = xcb_get_geometry_reply(c->c, xcb_get_geometry(c->c, pixmap), NULL);
-	if (!r) {
-		return false;
-	}
-
-	bool ret = r->width && r->height;
-	free(r);
-	return ret;
-}
-
 /// We don't use the _XSETROOT_ID root window property as a source of the background
 /// pixmap because it most likely points to a dummy pixmap used to keep the colormap
 /// associated with the background pixmap alive but we listen for it's changes and update

--- a/src/x.h
+++ b/src/x.h
@@ -408,6 +408,8 @@ struct xvisual_info x_get_visual_info(struct x_connection *c, xcb_visualid_t vis
 
 xcb_visualid_t x_get_visual_for_standard(struct x_connection *c, xcb_pict_standard_t std);
 
+xcb_visualid_t x_get_visual_for_depth(struct x_connection *c, uint8_t depth);
+
 xcb_render_pictformat_t
 x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std);
 

--- a/src/x.h
+++ b/src/x.h
@@ -356,8 +356,6 @@ const char *x_strerror(xcb_generic_error_t *e);
 
 xcb_pixmap_t x_create_pixmap(struct x_connection *, uint8_t depth, int width, int height);
 
-bool x_validate_pixmap(struct x_connection *, xcb_pixmap_t pxmap);
-
 /**
  * Free a <code>winprop_t</code>.
  *


### PR DESCRIPTION
previously we were using atoms set by other utilities to obtain the root back pixmap and the root's visual for it. however, their depths may mismatch. in this case picom will fail to bind the root back pixmap what causes errors, warnings and weird behavior on all backends:
```
$ build/src/picom --config=/dev/null --backend=xrender
[ 12/25/2022 17:15:37.319 x_create_picture_with_pictfmt_and_pixmap ERROR ] failed to create picture (X error 8 MATCH request 139 minor 4 serial 2232)
[ 12/25/2022 17:15:37.320 root_damaged ERROR ] Failed to bind root back pixmap
[ 12/25/2022 17:15:37.320 x_create_picture_with_pictfmt_and_pixmap ERROR ] failed to create picture (X error 8 MATCH request 139 minor 4 serial 2249)
[ 12/25/2022 17:15:37.320 root_damaged ERROR ] Failed to bind root back pixmap
...
$ build/src/picom --config=/dev/null --backend=glx
[ 12/25/2022 17:15:46.335 x_log_error WARN ] X error 8 MATCH request 152 minor 22 serial 725
[ 12/25/2022 17:15:46.335 x_log_error WARN ] X error 9 DRAWABLE request 156 minor 4 serial 726
[ 12/25/2022 17:15:46.335 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 16 serial 0
[ 12/25/2022 17:15:46.335 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 16 serial 0
[ 12/25/2022 17:15:46.336 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 23 serial 740
[ 12/25/2022 17:15:46.336 x_log_error WARN ] X error 8 MATCH request 152 minor 22 serial 743
[ 12/25/2022 17:15:46.336 x_log_error WARN ] X error 9 DRAWABLE request 156 minor 4 serial 744
[ 12/25/2022 17:15:46.336 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 16 serial 0
...
[ 12/25/2022 17:15:47.528 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 16 serial 0
[ 12/25/2022 17:15:47.528 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 23 serial 899
$ build/src/picom --config=/dev/null --legacy-backends --backend=xrender
[ 12/25/2022 17:16:12.626 x_create_picture_with_pictfmt_and_pixmap ERROR ] failed to create picture (X error 8 MATCH request 139 minor 4 serial 2258)
[ 12/25/2022 17:16:12.628 x_log_error WARN ] X error 143 RENDER_PICTURE request 139 minor 8 serial 2260
[ 12/25/2022 17:16:12.636 x_log_error WARN ] X error 143 RENDER_PICTURE request 139 minor 8 serial 2315
[ 12/25/2022 17:16:12.660 x_log_error WARN ] X error 143 RENDER_PICTURE request 139 minor 8 serial 2353
...
$ build/src/picom --config=/dev/null --legacy-backends --backend=glx
[ 12/25/2022 17:16:18.352 x_create_picture_with_pictfmt_and_pixmap ERROR ] failed to create picture (X error 8 MATCH request 139 minor 4 serial 2290)
[ 12/25/2022 17:16:18.353 x_log_error WARN ] X error 8 MATCH request 152 minor 22 serial 2293
[ 12/25/2022 17:16:18.353 x_log_error WARN ] X error 9 DRAWABLE request 156 minor 4 serial 2294
[ 12/25/2022 17:16:18.353 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 16 serial 0
...
[ 12/25/2022 17:16:19.580 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 16 serial 0
[ 12/25/2022 17:16:19.581 x_log_error WARN ] X error 161 GLX_BAD_PIXMAP request 152 minor 23 serial 2852
```

now we're using the root back pixmap's depth to obtain a suitable visual for it.

i've tested `feh`, `hsetroot` and `nitrogen` and they're all setting the right depth for the root back pixmap. however, *at least* `xfdesktop` (a part of the xfce desktop environment) always sets root back pixmap's depth to 32, when common root's depth is 24.

we could report this behavior upstream, but:
1) we're not sure if `xfdesktop` is completely wrong;
2) we're not sure if `xfdesktop` is the only one who does this;
3) there is a decent workaround for this and polybar already uses it.

if you think that this approach is wrong and there is a better way to workaround this, feel free to close this pull request. otherwise, feel free to request changes, i'll see what i can do.

related xfdesktop's code: https://github.com/xfce-mirror/xfdesktop/blob/f196763ba04211c7a3b21edba37c3b8f56b25516/src/xfce-desktop.c#L372-L374
related polybar's issue: https://github.com/polybar/polybar/issues/2798

~p.s. this pull request doesn't include a fix for legacy backends. it's an easy and pretty much the same fix for the legacy xrender backend, but legacy glx backend makes me doubt that fixing this worths the effort. if you want a fix for the legacy xrender backend included, hmu.~