### PR TITLE
backend: egl: fix creating eglpixmap

### DIFF
--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -285,8 +285,9 @@ egl_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, b
 
 	eglpixmap = cmalloc(struct egl_pixmap);
 	eglpixmap->pixmap = pixmap;
-	eglpixmap->image = eglCreateImageProc(gd->display, gd->ctx, EGL_NATIVE_PIXMAP_KHR,
-	                                      (EGLClientBuffer)(uintptr_t)pixmap, NULL);
+	eglpixmap->image =
+	    eglCreateImageProc(gd->display, EGL_NO_CONTEXT, EGL_NATIVE_PIXMAP_KHR,
+	                       (EGLClientBuffer)(uintptr_t)pixmap, NULL);
 	eglpixmap->owned = owned;
 
 	if (eglpixmap->image == EGL_NO_IMAGE) {


### PR DESCRIPTION
according to the specification of the EGL_KHR_image_pixmap extension, if target is EGL_NATIVE_PIXMAP then ctx must be EGL_NO_CONTEXT, otherwise, the EGL_BAD_PARAMETER error is generated. source: https://registry.khronos.org/EGL/extensions/KHR/EGL_KHR_image_pixmap.txt

fixes #981

btw, the commit that introduced the egl backend stated that `This needs the EGL_KHR_image_pixmap and the GL_EXT_EGL_image_storage extensions, which unfortunately aren't available on NVIDIA cards.`, but it works just fine for me (with this fix, ofc). how?!?!