### PR TITLE
use _checked functions with xcb_request_check

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -283,7 +283,8 @@ static inline void ev_map_notify(session_t *ps, xcb_map_notify_event_t *ev) {
 	// in redirected state.
 	if (ps->overlay && ev->window == ps->overlay && !ps->redirected) {
 		log_debug("Overlay is mapped while we are not redirected");
-		auto e = xcb_request_check(ps->c, xcb_unmap_window(ps->c, ps->overlay));
+		auto e =
+		    xcb_request_check(ps->c, xcb_unmap_window_checked(ps->c, ps->overlay));
 		if (e) {
 			log_error("Failed to unmap the overlay window");
 			free(e);

--- a/src/picom.c
+++ b/src/picom.c
@@ -1266,7 +1266,7 @@ static bool init_debug_window(session_t *ps) {
 		goto err_out;
 	}
 
-	err = xcb_request_check(ps->c, xcb_map_window(ps->c, ps->debug_window));
+	err = xcb_request_check(ps->c, xcb_map_window_checked(ps->c, ps->debug_window));
 	if (err) {
 		goto err_out;
 	}
@@ -2069,8 +2069,8 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	ps->sync_fence = XCB_NONE;
 	if (ps->xsync_exists) {
 		ps->sync_fence = x_new_id(ps->c);
-		e = xcb_request_check(
-		    ps->c, xcb_sync_create_fence(ps->c, ps->root, ps->sync_fence, 0));
+		e = xcb_request_check(ps->c, xcb_sync_create_fence_checked(
+		                                 ps->c, ps->root, ps->sync_fence, 0));
 		if (e) {
 			if (ps->o.xrender_sync_fence) {
 				log_error_x_error(e, "Failed to create a XSync fence. "
@@ -2280,7 +2280,7 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	xcb_query_tree_reply_t *query_tree_reply =
 	    xcb_query_tree_reply(ps->c, xcb_query_tree(ps->c, ps->root), NULL);
 
-	e = xcb_request_check(ps->c, xcb_ungrab_server(ps->c));
+	e = xcb_request_check(ps->c, xcb_ungrab_server_checked(ps->c));
 	if (e) {
 		log_fatal_x_error(e, "Failed to ungrab server");
 		free(e);

--- a/src/win.c
+++ b/src/win.c
@@ -1299,7 +1299,7 @@ void win_mark_client(session_t *ps, struct managed_win *w, xcb_window_t client) 
 	}
 
 	auto e = xcb_request_check(
-	    ps->c, xcb_change_window_attributes(
+	    ps->c, xcb_change_window_attributes_checked(
 	               ps->c, client, XCB_CW_EVENT_MASK,
 	               (const uint32_t[]){determine_evmask(ps, client, WIN_EVMODE_CLIENT)}));
 	if (e) {


### PR DESCRIPTION
there is the `XCB_AWAIT_VOID` wrapper but i don't think that it's supposed to replace all the `xcb_request_check` calls, so let's fix them.