### PR TITLE
picom: fix xcb_request_check memory leaks

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -1463,6 +1463,7 @@ static void handle_pending_updates(EV_P_ struct session *ps) {
 		auto e = xcb_request_check(ps->c, xcb_grab_server_checked(ps->c));
 		if (e) {
 			log_fatal_x_error(e, "failed to grab x server");
+			free(e);
 			return quit(ps);
 		}
 
@@ -1498,6 +1499,7 @@ static void handle_pending_updates(EV_P_ struct session *ps) {
 		e = xcb_request_check(ps->c, xcb_ungrab_server_checked(ps->c));
 		if (e) {
 			log_fatal_x_error(e, "failed to ungrab x server");
+			free(e);
 			return quit(ps);
 		}
 
@@ -1822,6 +1824,7 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	                                  XCB_EVENT_MASK_PROPERTY_CHANGE}));
 	if (e) {
 		log_error_x_error(e, "Failed to setup root window event mask");
+		free(e);
 	}
 
 	xcb_prefetch_extension_data(ps->c, &xcb_render_id);


### PR DESCRIPTION
to exit gracefully in case of errors