### PR TITLE
opengl: fix segfault in ensure_glx_context

### DIFF
--- a/src/opengl.h
+++ b/src/opengl.h
@@ -159,7 +159,7 @@ static inline bool ensure_glx_context(session_t *ps) {
 	if (!glx_has_context(ps))
 		glx_init(ps, false);
 
-	return ps->psglx->context;
+	return glx_has_context(ps);
 }
 
 /**


### PR DESCRIPTION
if there are issues with the legacy glx backend initialization, legacy xrender backend will segfault while probing for opengl-powered vsync methods.