### PR TITLE
backend: gl: do not leak back and default mask textures

### DIFF
--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -976,6 +976,9 @@ void gl_deinit(struct gl_data *gd) {
 		gd->default_shader = NULL;
 	}
 
+	glDeleteTextures(1, &gd->default_mask_texture);
+	glDeleteTextures(1, &gd->back_texture);
+
 	gl_check_err();
 }
 

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -188,10 +188,6 @@ void gl_present(backend_t *base, const region_t *);
 bool gl_read_pixel(backend_t *base, void *image_data, int x, int y, struct color *output);
 enum device_status gl_device_status(backend_t *base);
 
-static inline void gl_delete_texture(GLuint texture) {
-	glDeleteTextures(1, &texture);
-}
-
 /**
  * Get a textual representation of an OpenGL error.
  */


### PR DESCRIPTION
remove an unused function and fix two issues reported by leaktrace:
```
$ apitrace leaks picom.trace
33: error: texture 1 was not destroyed until 7003
40: error: texture 2 was not destroyed until 7003
$ apitrace dump --calls=20-49 picom.trace
// process.name = "/home/helix/Work/picom/build/src/picom"
20 glGenQueries(n = 2, ids = {1, 2})
21 glDisable(cap = GL_DEPTH_TEST)
22 glDepthMask(flag = GL_FALSE)
23 glEnable(cap = GL_BLEND)
24 glBlendFunc(sfactor = GL_ONE, dfactor = GL_ONE_MINUS_SRC_ALPHA)
25 glDisable(cap = GL_STENCIL_TEST)
26 glStencilMask(mask = 1)
27 glStencilFunc(func = GL_EQUAL, ref = 1, mask = 1)
28 glGetIntegerv(pname = GL_MAX_VIEWPORT_DIMS, params = {32768, 32768})
29 glViewport(x = 0, y = 0, width = 32768, height = 32768)
30 glClearColor(red = 0, green = 0, blue = 0, alpha = 1)
31 glClear(mask = GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT)
32 glGenFramebuffers(n = 1, framebuffers = &1)
33 glGenTextures(n = 1, textures = &1)
34 glBindTexture(target = GL_TEXTURE_2D, texture = 1)
35 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_MIN_FILTER, param = GL_LINEAR)
36 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_MAG_FILTER, param = GL_LINEAR)
37 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_WRAP_S, param = GL_CLAMP_TO_EDGE)
38 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_WRAP_T, param = GL_CLAMP_TO_EDGE)
39 glBindTexture(target = GL_TEXTURE_2D, texture = 0)
40 glGenTextures(n = 1, textures = &2)
41 glBindTexture(target = GL_TEXTURE_2D, texture = 2)
42 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_MIN_FILTER, param = GL_NEAREST)
43 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_MAG_FILTER, param = GL_NEAREST)
44 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_WRAP_S, param = GL_REPEAT)
45 glTexParameteri(target = GL_TEXTURE_2D, pname = GL_TEXTURE_WRAP_T, param = GL_REPEAT)
46 glBindTexture(target = GL_TEXTURE_2D, texture = 0)
47 glBindTexture(target = GL_TEXTURE_2D, texture = 2)
48 glTexImage2D(target = GL_TEXTURE_2D, level = 0, internalformat = GL_RED, width = 1, height = 1, border = 0, format = GL_RED, type = GL_UNSIGNED_BYTE, pixels = blob(1))
49 glBindTexture(target = GL_TEXTURE_2D, texture = 0)
```