### PR TITLE
backend: dummy: do not leak owned pixmaps

### DIFF
--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -17,6 +17,7 @@ struct dummy_image {
 	xcb_pixmap_t pixmap;
 	bool transparent;
 	int *refcount;
+	bool owned;
 	UT_hash_handle hh;
 };
 
@@ -42,6 +43,9 @@ void dummy_deinit(struct backend_base *data) {
 		log_warn("Backend image for pixmap %#010x is not freed", img->pixmap);
 		HASH_DEL(dummy->images, img);
 		free(img->refcount);
+		if (img->owned) {
+			xcb_free_pixmap(data->c, img->pixmap);
+		}
 		free(img);
 	}
 	free(dummy);
@@ -82,7 +86,7 @@ bool dummy_blur(struct backend_base *backend_data attr_unused, double opacity at
 }
 
 void *dummy_bind_pixmap(struct backend_base *base, xcb_pixmap_t pixmap,
-                        struct xvisual_info fmt, bool owned attr_unused) {
+                        struct xvisual_info fmt, bool owned) {
 	auto dummy = (struct dummy_data *)base;
 	struct dummy_image *img = NULL;
 	HASH_FIND_INT(dummy->images, &pixmap, img);
@@ -96,6 +100,7 @@ void *dummy_bind_pixmap(struct backend_base *base, xcb_pixmap_t pixmap,
 	img->transparent = fmt.alpha_size != 0;
 	img->refcount = ccalloc(1, int);
 	*img->refcount = 1;
+	img->owned = owned;
 
 	HASH_ADD_INT(dummy->images, pixmap, img);
 	return (void *)img;
@@ -112,6 +117,9 @@ void dummy_release_image(backend_t *base, void *image) {
 	if (*img->refcount == 0) {
 		HASH_DEL(dummy->images, img);
 		free(img->refcount);
+		if (img->owned) {
+			xcb_free_pixmap(base->c, img->pixmap);
+		}
 		free(img);
 	}
 }

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -162,7 +162,7 @@ void dummy_destroy_blur_context(struct backend_base *base attr_unused, void *ctx
 }
 
 void dummy_get_blur_size(void *ctx attr_unused, int *width, int *height) {
-	// These numbers are arbitrary, to make sure the reisze_region code path is
+	// These numbers are arbitrary, to make sure the resize_region code path is
 	// covered.
 	*width = 5;
 	*height = 5;


### PR DESCRIPTION
fix a typo and an issue reported by [xrescheck](https://github.com/absolutelynothelix/xrescheck):
```
$ xrescheck.sh -p resource_leaked -r -t xcb_composite_named_windows_pixmaps,xcb_pixmaps ~/Work/picom/build/src/picom --backend=dummy
? xrescheck 0.0.1 is here!
[ 06/13/2023 00:05:55.378 session_init INFO ] Switching to log file: /home/helix/.local/state/picom.log
? checking for leaked resources...
! 0x3200027 allocated by xcb_composite_name_window_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/win.c:326
	/home/helix/Work/picom/build/../src/win.c:573
	/home/helix/Work/picom/build/../src/picom.c:1670 (discriminator 2)
! 0x320002b allocated by xcb_create_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/x.c:599
	/home/helix/Work/picom/build/../src/backend/backend_common.c:212
	/home/helix/Work/picom/build/../src/backend/backend_common.c:302
! 0x320002f allocated by xcb_composite_name_window_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/win.c:326
	/home/helix/Work/picom/build/../src/win.c:573
	/home/helix/Work/picom/build/../src/picom.c:1670 (discriminator 2)
! 0x3200033 allocated by xcb_create_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/x.c:599
	/home/helix/Work/picom/build/../src/backend/backend_common.c:212
	/home/helix/Work/picom/build/../src/backend/backend_common.c:302
! 0x3200037 allocated by xcb_composite_name_window_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/win.c:326
	/home/helix/Work/picom/build/../src/win.c:573
	/home/helix/Work/picom/build/../src/picom.c:1670 (discriminator 2)
! 0x320003b allocated by xcb_create_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/x.c:599
	/home/helix/Work/picom/build/../src/backend/backend_common.c:212
	/home/helix/Work/picom/build/../src/backend/backend_common.c:302
! 0x320003f allocated by xcb_composite_name_window_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/win.c:326
	/home/helix/Work/picom/build/../src/win.c:573
	/home/helix/Work/picom/build/../src/picom.c:1670 (discriminator 2)
! 0x3200043 allocated by xcb_create_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/x.c:599
	/home/helix/Work/picom/build/../src/backend/backend_common.c:212
	/home/helix/Work/picom/build/../src/backend/backend_common.c:302
! 0x3200047 allocated by xcb_composite_name_window_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/win.c:326
	/home/helix/Work/picom/build/../src/win.c:573
	/home/helix/Work/picom/build/../src/picom.c:1670 (discriminator 2)
! 0x320004b allocated by xcb_create_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/x.c:599
	/home/helix/Work/picom/build/../src/backend/backend_common.c:212
	/home/helix/Work/picom/build/../src/backend/backend_common.c:302
! 0x320004f allocated by xcb_composite_name_window_pixmap_checked wasn't freed, the allocation was made here:
	/home/helix/Work/picom/build/../src/win.c:326
	/home/helix/Work/picom/build/../src/win.c:573
	/home/helix/Work/picom/build/../src/picom.c:1670 (discriminator 2)
```