### PR TITLE
core: added proper event handling for XESetWireToEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 * libXext
 * xproto
 * xcb
+* xcb-util
 * xcb-damage
 * xcb-dpms
 * xcb-xfixes

--- a/src/event.c
+++ b/src/event.c
@@ -107,7 +107,7 @@ static inline xcb_window_t attr_pure ev_window(session_t *ps, xcb_generic_event_
 
 static inline const char *ev_name(session_t *ps, xcb_generic_event_t *ev) {
 	static char buf[128];
-	switch (ev->response_type & 0x7f) {
+	switch (XCB_EVENT_RESPONSE_TYPE(ev)) {
 		CASESTRRET(FocusIn);
 		CASESTRRET(FocusOut);
 		CASESTRRET(CreateNotify);
@@ -666,7 +666,7 @@ ev_selection_clear(session_t *ps, xcb_selection_clear_event_t attr_unused *ev) {
 }
 
 void ev_handle(session_t *ps, xcb_generic_event_t *ev) {
-	if ((ev->response_type & 0x7f) != KeymapNotify) {
+	if (XCB_EVENT_RESPONSE_TYPE(ev) != KeymapNotify) {
 		discard_pending(ps, ev->full_sequence);
 	}
 
@@ -688,9 +688,10 @@ void ev_handle(session_t *ps, xcb_generic_event_t *ev) {
 	// For even more details, see:
 	// https://bugs.freedesktop.org/show_bug.cgi?id=35945
 	// https://lists.freedesktop.org/archives/xcb/2011-November/007337.html
-	auto proc = XESetWireToEvent(ps->dpy, XCB_EVENT_RESPONSE_TYPE(ev), 0);
+	auto response_type = XCB_EVENT_RESPONSE_TYPE(ev);
+	auto proc = XESetWireToEvent(ps->dpy, response_type, 0);
 	if (proc) {
-		XESetWireToEvent(ps->dpy, XCB_EVENT_RESPONSE_TYPE(ev), proc);
+		XESetWireToEvent(ps->dpy, response_type, proc);
 		XEvent dummy;
 
 		// Stop Xlib from complaining about lost sequence numbers.
@@ -709,6 +710,7 @@ void ev_handle(session_t *ps, xcb_generic_event_t *ev) {
 	// XXX redraw needs to be more fine grained
 	queue_redraw(ps);
 
+	// the events sent from SendEvent will be ignored
 	switch (ev->response_type) {
 	case FocusIn: ev_focus_in(ps, (xcb_focus_in_event_t *)ev); break;
 	case FocusOut: ev_focus_out(ps, (xcb_focus_out_event_t *)ev); break;

--- a/src/event.c
+++ b/src/event.c
@@ -7,6 +7,7 @@
 #include <X11/extensions/sync.h>
 #include <xcb/damage.h>
 #include <xcb/randr.h>
+#include <xcb/xcb_event.h>
 
 #include "atom.h"
 #include "common.h"
@@ -687,9 +688,9 @@ void ev_handle(session_t *ps, xcb_generic_event_t *ev) {
 	// For even more details, see:
 	// https://bugs.freedesktop.org/show_bug.cgi?id=35945
 	// https://lists.freedesktop.org/archives/xcb/2011-November/007337.html
-	auto proc = XESetWireToEvent(ps->dpy, ev->response_type, 0);
+	auto proc = XESetWireToEvent(ps->dpy, XCB_EVENT_RESPONSE_TYPE(ev), 0);
 	if (proc) {
-		XESetWireToEvent(ps->dpy, ev->response_type, proc);
+		XESetWireToEvent(ps->dpy, XCB_EVENT_RESPONSE_TYPE(ev), proc);
 		XEvent dummy;
 
 		// Stop Xlib from complaining about lost sequence numbers.

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,7 +20,7 @@ required_xcb_packages = [
 ]
 
 required_packages = [
-	'x11', 'x11-xcb', 'xcb-renderutil', 'xcb-image', 'xext', 'pixman-1'
+	'x11', 'x11-xcb', 'xcb-renderutil', 'xcb-image', 'xext', 'pixman-1', 'xcb-util'
 ]
 
 foreach i : required_packages
@@ -30,8 +30,6 @@ endforeach
 foreach i : required_xcb_packages
 	base_deps += [dependency(i, version: '>=1.12.0', required: true)]
 endforeach
-
-base_deps += [dependency('xcb-util', version: '>=0.4.0', required: true)]
 
 if not cc.has_header('uthash.h')
   error('Dependency uthash not found')

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,6 +31,8 @@ foreach i : required_xcb_packages
 	base_deps += [dependency(i, version: '>=1.12.0', required: true)]
 endforeach
 
+base_deps += [dependency('xcb-util', version: '>=0.4.0', required: true)]
+
 if not cc.has_header('uthash.h')
   error('Dependency uthash not found')
 endif


### PR DESCRIPTION
See: https://tudorr.ro/res/docs/xcb/util/group__xcb____event__t.html

Fixes these Xlib errors:

![image](https://github.com/yshui/picom/assets/3750982/07d9435f-e5a3-4a08-a5b5-bb0d4bd9beb1)

