### PR TITLE
win: don't re-bind mask image when there is already one

### DIFF
--- a/src/win.c
+++ b/src/win.c
@@ -369,6 +369,7 @@ bool win_bind_shadow(struct backend_base *b, struct managed_win *w, struct color
 		w->shadow_image = b->ops->render_shadow(b, w->widthb, w->heightb, sctx, c);
 	} else {
 		if (!w->mask_image) {
+			// It's possible we already allocated a mask because of background blur
 			win_bind_mask(b, w);
 		}
 		w->shadow_image = b->ops->shadow_from_mask(b, w->mask_image, sctx, c);

--- a/src/win.c
+++ b/src/win.c
@@ -368,7 +368,9 @@ bool win_bind_shadow(struct backend_base *b, struct managed_win *w, struct color
 	    b->ops->shadow_from_mask == NULL) {
 		w->shadow_image = b->ops->render_shadow(b, w->widthb, w->heightb, sctx, c);
 	} else {
-		win_bind_mask(b, w);
+		if (!w->mask_image) {
+			win_bind_mask(b, w);
+		}
 		w->shadow_image = b->ops->shadow_from_mask(b, w->mask_image, sctx, c);
 	}
 	if (!w->shadow_image) {


### PR DESCRIPTION
For some reason, it may happen that mask_image exists, causing a memory leak in win_bind_mask. Since `assert(!w->mask_image);` has been added, there are random crashes.

```
Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7fa0f26b4a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x555f7f92138c in default_new_backend_image ../src/backend/backend_common.c:497
    #2 0x555f7f961d4c in gl_make_mask ../src/backend/gl/gl_common.c:712
    #3 0x555f7f81f73e in win_bind_mask ../src/win.c:353
    #4 0x555f7f94ee79 in paint_all_new ../src/backend/backend.c:235
    #5 0x555f7f7f4dda in draw_callback_impl ../src/picom.c:1830
    #6 0x555f7f7f531b in draw_callback ../src/picom.c:1858
    #7 0x7fa0f3078772 in ev_invoke_pending (/lib/x86_64-linux-gnu/libev.so.4+0x5772)
```

It happens randomly, so this bug is hard to catch.

I just did like this: [backend.c](https://github.com/yshui/picom/blob/next/src/backend/backend.c#L234) The crashes seem to be gone.
