### PR TITLE
core: drop xcb-glx

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     # Install dependencies
-    - run: sudo apt update && sudo apt install libxext-dev libxcb1-dev libxcb-dpms0-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-glx0-dev libxcb-util-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl1-mesa-dev  libpcre2-dev  libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson ninja-build
+    - run: sudo apt update && sudo apt install libxext-dev libxcb1-dev libxcb-dpms0-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-util-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl1-mesa-dev  libpcre2-dev  libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson ninja-build
       if: ${{ matrix.language == 'cpp' }}
 
     # Autobuild

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 * xcb-composite
 * xcb-image
 * xcb-present
-* xcb-glx
 * pixman
 * libdbus (optional, disable with the `-Ddbus=false` meson configure flag)
 * libconfig (optional, disable with the `-Dconfig_file=false` meson configure flag)
@@ -49,7 +48,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 On Debian based distributions (e.g. Ubuntu), the needed packages are
 
 ```
-libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-dpms0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-glx0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl-dev libegl-dev libpcre2-dev libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson
+libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-dpms0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl-dev libegl-dev libpcre2-dev libevdev-dev uthash-dev libev-dev libx11-xcb-dev meson
 ```
 
 On Fedora, the needed packages are

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -244,10 +244,12 @@ static backend_t *glx_init(session_t *ps) {
 	XVisualInfo *pvis = NULL;
 
 	// Check for GLX extension
-	if (!ps->glx_exists) {
+	if (!glXQueryExtension(ps->dpy, &ps->glx_error, &ps->glx_event)) {
 		log_error("No GLX extension.");
 		goto end;
 	}
+
+	ps->glx_exists = true;
 
 	// Get XVisualInfo
 	int nitems = 0;

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,7 @@ cflags = []
 
 required_xcb_packages = [
 	'xcb-render', 'xcb-damage', 'xcb-randr', 'xcb-sync', 'xcb-composite',
-	'xcb-shape', 'xcb-xfixes', 'xcb-present', 'xcb-glx', 'xcb-dpms', 'xcb'
+	'xcb-shape', 'xcb-xfixes', 'xcb-present', 'xcb-dpms', 'xcb'
 ]
 
 required_packages = [

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -50,10 +50,12 @@ bool glx_init(session_t *ps, bool need_render) {
 	XVisualInfo *pvis = NULL;
 
 	// Check for GLX extension
-	if (!ps->glx_exists) {
+	if (!glXQueryExtension(ps->dpy, &ps->glx_error, &ps->glx_event)) {
 		log_error("No GLX extension.");
 		goto glx_init_end;
 	}
+
+	ps->glx_exists = true;
 
 	// Get XVisualInfo
 	pvis = get_visualinfo_from_visual(ps, ps->vis);

--- a/src/picom.c
+++ b/src/picom.c
@@ -25,7 +25,6 @@
 #include <xcb/composite.h>
 #include <xcb/damage.h>
 #include <xcb/dpms.h>
-#include <xcb/glx.h>
 #include <xcb/present.h>
 #include <xcb/randr.h>
 #include <xcb/render.h>
@@ -2098,7 +2097,6 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	xcb_prefetch_extension_data(ps->c, &xcb_randr_id);
 	xcb_prefetch_extension_data(ps->c, &xcb_present_id);
 	xcb_prefetch_extension_data(ps->c, &xcb_sync_id);
-	xcb_prefetch_extension_data(ps->c, &xcb_glx_id);
 	xcb_prefetch_extension_data(ps->c, &xcb_dpms_id);
 
 	ext_info = xcb_get_extension_data(ps->c, &xcb_render_id);
@@ -2159,13 +2157,6 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	if (!XCB_AWAIT_VOID(xcb_xfixes_create_region, ps->c, ps->damaged_region, 0, NULL)) {
 		log_fatal("Failed to create a XFixes region");
 		goto err;
-	}
-
-	ext_info = xcb_get_extension_data(ps->c, &xcb_glx_id);
-	if (ext_info && ext_info->present) {
-		ps->glx_exists = true;
-		ps->glx_error = ext_info->first_error;
-		ps->glx_event = ext_info->first_event;
 	}
 
 	ext_info = xcb_get_extension_data(ps->c, &xcb_dpms_id);

--- a/src/x.c
+++ b/src/x.c
@@ -4,17 +4,19 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include <X11/Xmd.h>
 #include <X11/Xutil.h>
 #include <pixman.h>
 #include <xcb/composite.h>
 #include <xcb/damage.h>
-#include <xcb/glx.h>
 #include <xcb/randr.h>
 #include <xcb/render.h>
 #include <xcb/sync.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_renderutil.h>
 #include <xcb/xfixes.h>
+
+#include <GL/glxproto.h>
 
 #include "atom.h"
 #ifdef CONFIG_OPENGL
@@ -507,20 +509,20 @@ _x_strerror(unsigned long serial, uint8_t major, uint16_t minor, uint8_t error_c
 	if (ps->glx_exists) {
 		o = error_code - ps->glx_error;
 		switch (o) {
-			CASESTRRET2(GLX_BAD_CONTEXT);
-			CASESTRRET2(GLX_BAD_CONTEXT_STATE);
-			CASESTRRET2(GLX_BAD_DRAWABLE);
-			CASESTRRET2(GLX_BAD_PIXMAP);
-			CASESTRRET2(GLX_BAD_CONTEXT_TAG);
-			CASESTRRET2(GLX_BAD_CURRENT_WINDOW);
-			CASESTRRET2(GLX_BAD_RENDER_REQUEST);
-			CASESTRRET2(GLX_BAD_LARGE_REQUEST);
-			CASESTRRET2(GLX_UNSUPPORTED_PRIVATE_REQUEST);
-			CASESTRRET2(GLX_BAD_FB_CONFIG);
-			CASESTRRET2(GLX_BAD_PBUFFER);
-			CASESTRRET2(GLX_BAD_CURRENT_DRAWABLE);
-			CASESTRRET2(GLX_BAD_WINDOW);
-			CASESTRRET2(GLX_GLX_BAD_PROFILE_ARB);
+			CASESTRRET(GLXBadContext);
+			CASESTRRET(GLXBadContextState);
+			CASESTRRET(GLXBadDrawable);
+			CASESTRRET(GLXBadPixmap);
+			CASESTRRET(GLXBadContextTag);
+			CASESTRRET(GLXBadCurrentWindow);
+			CASESTRRET(GLXBadRenderRequest);
+			CASESTRRET(GLXBadLargeRequest);
+			CASESTRRET(GLXUnsupportedPrivateRequest);
+			CASESTRRET(GLXBadFBConfig);
+			CASESTRRET(GLXBadPbuffer);
+			CASESTRRET(GLXBadCurrentDrawable);
+			CASESTRRET(GLXBadWindow);
+			CASESTRRET(GLXBadProfileARB);
 		}
 	}
 


### PR DESCRIPTION
it's only used for querying the x glx extension and it's error definitions. other than this, it has little to no use for us. see https://stackoverflow.com/q/41069032 for details.