### PR TITLE
core: isolate X connection with error handling into a struct

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -91,10 +91,10 @@ void paint_all_new(session_t *ps, struct managed_win *t) {
 		return handle_device_reset(ps);
 	}
 	if (ps->o.xrender_sync_fence) {
-		if (ps->xsync_exists && !x_fence_sync(ps->c, ps->sync_fence)) {
+		if (ps->xsync_exists && !x_fence_sync(&ps->c, ps->sync_fence)) {
 			log_error("x_fence_sync failed, xrender-sync-fence will be "
 			          "disabled from now on.");
-			xcb_sync_destroy_fence(ps->c, ps->sync_fence);
+			xcb_sync_destroy_fence(ps->c.c, ps->sync_fence);
 			ps->sync_fence = XCB_NONE;
 			ps->o.xrender_sync_fence = false;
 			ps->xsync_exists = false;
@@ -348,7 +348,7 @@ void paint_all_new(session_t *ps, struct managed_win *t) {
 			}
 
 			if (ps->o.crop_shadow_to_monitor && w->randr_monitor >= 0 &&
-			    w->randr_monitor < ps->randr_nmonitors) {
+			    w->randr_monitor < ps->monitors.count) {
 				// There can be a window where number of monitors is
 				// updated, but the monitor number attached to the window
 				// have not.
@@ -358,7 +358,7 @@ void paint_all_new(session_t *ps, struct managed_win *t) {
 				// bounds.
 				pixman_region32_intersect(
 				    &reg_shadow, &reg_shadow,
-				    &ps->randr_monitor_regs[w->randr_monitor]);
+				    &ps->monitors.regions[w->randr_monitor]);
 			}
 
 			if (ps->o.transparent_clipping) {

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -23,8 +23,7 @@ struct backend_operations;
 
 typedef struct backend_base {
 	struct backend_operations *ops;
-	xcb_connection_t *c;
-	xcb_window_t root;
+	struct x_connection *c;
 	struct ev_loop *loop;
 
 	/// Whether the backend can accept new render request at the moment

--- a/src/backend/backend_common.c
+++ b/src/backend/backend_common.c
@@ -19,17 +19,18 @@
 /**
  * Generate a 1x1 <code>Picture</code> of a particular color.
  */
-xcb_render_picture_t solid_picture(xcb_connection_t *c, xcb_drawable_t d, bool argb,
-                                   double a, double r, double g, double b) {
+xcb_render_picture_t
+solid_picture(struct x_connection *c, bool argb, double a, double r, double g, double b) {
 	xcb_pixmap_t pixmap;
 	xcb_render_picture_t picture;
 	xcb_render_create_picture_value_list_t pa;
 	xcb_render_color_t col;
 	xcb_rectangle_t rect;
 
-	pixmap = x_create_pixmap(c, argb ? 32 : 8, d, 1, 1);
-	if (!pixmap)
+	pixmap = x_create_pixmap(c, argb ? 32 : 8, 1, 1);
+	if (!pixmap) {
 		return XCB_NONE;
+	}
 
 	pa.repeat = 1;
 	picture = x_create_picture_with_standard_and_pixmap(
@@ -37,7 +38,7 @@ xcb_render_picture_t solid_picture(xcb_connection_t *c, xcb_drawable_t d, bool a
 	    XCB_RENDER_CP_REPEAT, &pa);
 
 	if (!picture) {
-		xcb_free_pixmap(c, pixmap);
+		xcb_free_pixmap(c->c, pixmap);
 		return XCB_NONE;
 	}
 
@@ -51,14 +52,14 @@ xcb_render_picture_t solid_picture(xcb_connection_t *c, xcb_drawable_t d, bool a
 	rect.width = 1;
 	rect.height = 1;
 
-	xcb_render_fill_rectangles(c, XCB_RENDER_PICT_OP_SRC, picture, col, 1, &rect);
-	xcb_free_pixmap(c, pixmap);
+	xcb_render_fill_rectangles(c->c, XCB_RENDER_PICT_OP_SRC, picture, col, 1, &rect);
+	xcb_free_pixmap(c->c, pixmap);
 
 	return picture;
 }
 
-xcb_image_t *
-make_shadow(xcb_connection_t *c, const conv *kernel, double opacity, int width, int height) {
+xcb_image_t *make_shadow(struct x_connection *c, const conv *kernel, double opacity,
+                         int width, int height) {
 	/*
 	 * We classify shadows into 4 kinds of regions
 	 *    r = shadow radius
@@ -84,8 +85,9 @@ make_shadow(xcb_connection_t *c, const conv *kernel, double opacity, int width, 
 	assert(d % 2 == 1);
 	assert(d > 0);
 
-	ximage = xcb_image_create_native(c, to_u16_checked(swidth), to_u16_checked(sheight),
-	                                 XCB_IMAGE_FORMAT_Z_PIXMAP, 8, 0, 0, NULL);
+	ximage =
+	    xcb_image_create_native(c->c, to_u16_checked(swidth), to_u16_checked(sheight),
+	                            XCB_IMAGE_FORMAT_Z_PIXMAP, 8, 0, 0, NULL);
 	if (!ximage) {
 		log_error("failed to create an X image");
 		return 0;
@@ -193,7 +195,7 @@ make_shadow(xcb_connection_t *c, const conv *kernel, double opacity, int width, 
 /**
  * Generate shadow <code>Picture</code> for a window.
  */
-bool build_shadow(xcb_connection_t *c, xcb_drawable_t d, double opacity, const int width,
+bool build_shadow(struct x_connection *c, double opacity, const int width,
                   const int height, const conv *kernel, xcb_render_picture_t shadow_pixel,
                   xcb_pixmap_t *pixmap, xcb_render_picture_t *pict) {
 	xcb_image_t *shadow_image = NULL;
@@ -207,9 +209,9 @@ bool build_shadow(xcb_connection_t *c, xcb_drawable_t d, double opacity, const i
 		return false;
 	}
 
-	shadow_pixmap = x_create_pixmap(c, 8, d, shadow_image->width, shadow_image->height);
+	shadow_pixmap = x_create_pixmap(c, 8, shadow_image->width, shadow_image->height);
 	shadow_pixmap_argb =
-	    x_create_pixmap(c, 32, d, shadow_image->width, shadow_image->height);
+	    x_create_pixmap(c, 32, shadow_image->width, shadow_image->height);
 
 	if (!shadow_pixmap || !shadow_pixmap_argb) {
 		log_error("Failed to create shadow pixmaps");
@@ -225,11 +227,11 @@ bool build_shadow(xcb_connection_t *c, xcb_drawable_t d, double opacity, const i
 	}
 
 	gc = x_new_id(c);
-	xcb_create_gc(c, gc, shadow_pixmap, 0, NULL);
+	xcb_create_gc(c->c, gc, shadow_pixmap, 0, NULL);
 
 	// We need to make room for protocol metadata in the request. The metadata should
 	// be 24 bytes plus padding, let's be generous and give it 1kb
-	auto maximum_image_size = xcb_get_maximum_request_length(c) * 4 - 1024;
+	auto maximum_image_size = xcb_get_maximum_request_length(c->c) * 4 - 1024;
 	auto maximum_row =
 	    to_u16_checked(clamp(maximum_image_size / shadow_image->stride, 0, UINT16_MAX));
 	if (maximum_row <= 0) {
@@ -248,23 +250,23 @@ bool build_shadow(xcb_connection_t *c, xcb_drawable_t d, double opacity, const i
 		}
 
 		uint32_t offset = row * shadow_image->stride / sizeof(*shadow_image->data);
-		xcb_put_image(c, (uint8_t)shadow_image->format, shadow_pixmap, gc,
+		xcb_put_image(c->c, (uint8_t)shadow_image->format, shadow_pixmap, gc,
 		              shadow_image->width, batch_height, 0, to_i16_checked(row),
 		              0, shadow_image->depth, shadow_image->stride * batch_height,
 		              shadow_image->data + offset);
 	}
 
-	xcb_render_composite(c, XCB_RENDER_PICT_OP_SRC, shadow_pixel, shadow_picture,
+	xcb_render_composite(c->c, XCB_RENDER_PICT_OP_SRC, shadow_pixel, shadow_picture,
 	                     shadow_picture_argb, 0, 0, 0, 0, 0, 0, shadow_image->width,
 	                     shadow_image->height);
 
 	*pixmap = shadow_pixmap_argb;
 	*pict = shadow_picture_argb;
 
-	xcb_free_gc(c, gc);
+	xcb_free_gc(c->c, gc);
 	xcb_image_destroy(shadow_image);
-	xcb_free_pixmap(c, shadow_pixmap);
-	xcb_render_free_picture(c, shadow_picture);
+	xcb_free_pixmap(c->c, shadow_pixmap);
+	x_free_picture(c, shadow_picture);
 
 	return true;
 
@@ -273,19 +275,19 @@ shadow_picture_err:
 		xcb_image_destroy(shadow_image);
 	}
 	if (shadow_pixmap) {
-		xcb_free_pixmap(c, shadow_pixmap);
+		xcb_free_pixmap(c->c, shadow_pixmap);
 	}
 	if (shadow_pixmap_argb) {
-		xcb_free_pixmap(c, shadow_pixmap_argb);
+		xcb_free_pixmap(c->c, shadow_pixmap_argb);
 	}
 	if (shadow_picture) {
-		xcb_render_free_picture(c, shadow_picture);
+		x_free_picture(c, shadow_picture);
 	}
 	if (shadow_picture_argb) {
-		xcb_render_free_picture(c, shadow_picture_argb);
+		x_free_picture(c, shadow_picture_argb);
 	}
 	if (gc) {
-		xcb_free_gc(c, gc);
+		xcb_free_gc(c->c, gc);
 	}
 
 	return false;
@@ -294,22 +296,22 @@ shadow_picture_err:
 void *default_backend_render_shadow(backend_t *backend_data, int width, int height,
                                     struct backend_shadow_context *sctx, struct color color) {
 	const conv *kernel = (void *)sctx;
-	xcb_render_picture_t shadow_pixel = solid_picture(
-	    backend_data->c, backend_data->root, true, 1, color.red, color.green, color.blue);
+	xcb_render_picture_t shadow_pixel =
+	    solid_picture(backend_data->c, true, 1, color.red, color.green, color.blue);
 	xcb_pixmap_t shadow = XCB_NONE;
 	xcb_render_picture_t pict = XCB_NONE;
 
-	if (!build_shadow(backend_data->c, backend_data->root, color.alpha, width, height,
-	                  kernel, shadow_pixel, &shadow, &pict)) {
-		xcb_render_free_picture(backend_data->c, shadow_pixel);
+	if (!build_shadow(backend_data->c, color.alpha, width, height, kernel,
+	                  shadow_pixel, &shadow, &pict)) {
+		x_free_picture(backend_data->c, shadow_pixel);
 		return NULL;
 	}
 
 	auto visual = x_get_visual_for_standard(backend_data->c, XCB_PICT_STANDARD_ARGB_32);
 	void *ret = backend_data->ops->bind_pixmap(
 	    backend_data, shadow, x_get_visual_info(backend_data->c, visual), true);
-	xcb_render_free_picture(backend_data->c, pict);
-	xcb_render_free_picture(backend_data->c, shadow_pixel);
+	x_free_picture(backend_data->c, pict);
+	x_free_picture(backend_data->c, shadow_pixel);
 	return ret;
 }
 
@@ -506,9 +508,8 @@ struct backend_image *default_new_backend_image(int w, int h) {
 }
 
 void init_backend_base(struct backend_base *base, session_t *ps) {
-	base->c = ps->c;
+	base->c = &ps->c;
 	base->loop = ps->loop;
-	base->root = ps->root;
 	base->busy = false;
 	base->ops = NULL;
 }

--- a/src/backend/backend_common.h
+++ b/src/backend/backend_common.h
@@ -44,15 +44,15 @@ struct backend_image {
 	int border_width;
 };
 
-bool build_shadow(xcb_connection_t *, xcb_drawable_t, double opacity, int width,
-                  int height, const conv *kernel, xcb_render_picture_t shadow_pixel,
+bool build_shadow(struct x_connection *, double opacity, int width, int height,
+                  const conv *kernel, xcb_render_picture_t shadow_pixel,
                   xcb_pixmap_t *pixmap, xcb_render_picture_t *pict);
 
-xcb_render_picture_t solid_picture(xcb_connection_t *, xcb_drawable_t, bool argb,
-                                   double a, double r, double g, double b);
+xcb_render_picture_t
+solid_picture(struct x_connection *, bool argb, double a, double r, double g, double b);
 
-xcb_image_t *
-make_shadow(xcb_connection_t *c, const conv *kernel, double opacity, int width, int height);
+xcb_image_t *make_shadow(struct x_connection *c, const conv *kernel, double opacity,
+                         int width, int height);
 
 /// The default implementation of `is_win_transparent`, it simply looks at win::mode. So
 /// this is not suitable for backends that alter the content of windows

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -30,9 +30,8 @@ struct dummy_data {
 
 struct backend_base *dummy_init(struct session *ps attr_unused) {
 	auto ret = (struct backend_base *)ccalloc(1, struct dummy_data);
-	ret->c = ps->c;
+	ret->c = &ps->c;
 	ret->loop = ps->loop;
-	ret->root = ps->root;
 	ret->busy = false;
 	return ret;
 }
@@ -44,7 +43,7 @@ void dummy_deinit(struct backend_base *data) {
 		HASH_DEL(dummy->images, img);
 		free(img->refcount);
 		if (img->owned) {
-			xcb_free_pixmap(data->c, img->pixmap);
+			xcb_free_pixmap(data->c->c, img->pixmap);
 		}
 		free(img);
 	}
@@ -118,7 +117,7 @@ void dummy_release_image(backend_t *base, void *image) {
 		HASH_DEL(dummy->images, img);
 		free(img->refcount);
 		if (img->owned) {
-			xcb_free_pixmap(base->c, img->pixmap);
+			xcb_free_pixmap(base->c->c, img->pixmap);
 		}
 		free(img);
 	}

--- a/src/backend/gl/glx.h
+++ b/src/backend/gl/glx.h
@@ -41,8 +41,7 @@ struct glx_fbconfig_criteria {
 	int visual_depth;
 };
 
-struct glx_fbconfig_info *glx_find_fbconfig(Display *, int screen, struct xvisual_info);
-
+struct glx_fbconfig_info *glx_find_fbconfig(struct x_connection *, struct xvisual_info);
 
 struct glxext_info {
 	bool initialized;

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -1165,7 +1165,7 @@ static bool cdbus_process_opts_get(session_t *ps, DBusMessage *msg) {
 
 	// display
 	if (!strcmp("display", target)) {
-		cdbus_reply_string(ps, msg, DisplayString(ps->dpy));
+		cdbus_reply_string(ps, msg, DisplayString(ps->c.dpy));
 		return true;
 	}
 

--- a/src/picom.h
+++ b/src/picom.h
@@ -94,7 +94,7 @@ free_win_res_glx(session_t *ps attr_unused, struct managed_win *w attr_unused) {
  * Dump an drawable's info.
  */
 static inline void dump_drawable(session_t *ps, xcb_drawable_t drawable) {
-	auto r = xcb_get_geometry_reply(ps->c, xcb_get_geometry(ps->c, drawable), NULL);
+	auto r = xcb_get_geometry_reply(ps->c.c, xcb_get_geometry(ps->c.c, drawable), NULL);
 	if (!r) {
 		log_trace("Drawable %#010x: Failed", drawable);
 		return;

--- a/src/render.h
+++ b/src/render.h
@@ -39,8 +39,6 @@ void paint_one(session_t *ps, struct managed_win *w, const region_t *reg_paint);
 
 void paint_all(session_t *ps, struct managed_win *const t);
 
-void free_picture(xcb_connection_t *c, xcb_render_picture_t *p);
-
 void free_paint(session_t *ps, paint_t *ppaint);
 void free_root_tile(session_t *ps);
 

--- a/src/vsync.c
+++ b/src/vsync.c
@@ -77,31 +77,35 @@ static bool vsync_drm_init(session_t *ps) {
  * @return true for success, false otherwise
  */
 static bool vsync_opengl_init(session_t *ps) {
-	if (!ensure_glx_context(ps))
+	if (!ensure_glx_context(ps)) {
 		return false;
+	}
 
 	return glxext.has_GLX_SGI_video_sync;
 }
 
 static bool vsync_opengl_oml_init(session_t *ps) {
-	if (!ensure_glx_context(ps))
+	if (!ensure_glx_context(ps)) {
 		return false;
+	}
 
 	return glxext.has_GLX_OML_sync_control;
 }
 
 static inline bool vsync_opengl_swc_swap_interval(session_t *ps, int interval) {
-	if (glxext.has_GLX_MESA_swap_control)
+	if (glxext.has_GLX_MESA_swap_control) {
 		return glXSwapIntervalMESA((uint)interval) == 0;
-	else if (glxext.has_GLX_SGI_swap_control)
+	}
+	if (glxext.has_GLX_SGI_swap_control) {
 		return glXSwapIntervalSGI(interval) == 0;
-	else if (glxext.has_GLX_EXT_swap_control) {
+	}
+	if (glxext.has_GLX_EXT_swap_control) {
 		GLXDrawable d = glXGetCurrentDrawable();
 		if (d == None) {
 			// We don't have a context??
 			return false;
 		}
-		glXSwapIntervalEXT(ps->dpy, glXGetCurrentDrawable(), interval);
+		glXSwapIntervalEXT(ps->c.dpy, glXGetCurrentDrawable(), interval);
 		return true;
 	}
 	return false;
@@ -140,8 +144,8 @@ static int vsync_opengl_wait(session_t *ps attr_unused) {
 static int vsync_opengl_oml_wait(session_t *ps) {
 	int64_t ust = 0, msc = 0, sbc = 0;
 
-	glXGetSyncValuesOML(ps->dpy, ps->reg_win, &ust, &msc, &sbc);
-	glXWaitForMscOML(ps->dpy, ps->reg_win, 0, 2, (msc + 1) % 2, &ust, &msc, &sbc);
+	glXGetSyncValuesOML(ps->c.dpy, ps->reg_win, &ust, &msc, &sbc);
+	glXWaitForMscOML(ps->c.dpy, ps->reg_win, 0, 2, (msc + 1) % 2, &ust, &msc, &sbc);
 	return 0;
 }
 #endif

--- a/src/win.h
+++ b/src/win.h
@@ -341,9 +341,7 @@ void win_recheck_client(session_t *ps, struct managed_win *w);
 double attr_pure win_calc_opacity_target(session_t *ps, const struct managed_win *w);
 bool attr_pure win_should_dim(session_t *ps, const struct managed_win *w);
 
-// TODO(absolutelynothelix): rename to x_update_win_(randr_?)monitor and move to
-// the x.h.
-void win_update_monitor(int nmons, region_t *mons, struct managed_win *mw);
+void win_update_monitor(struct x_monitors *monitors, struct managed_win *mw);
 
 /**
  * Retrieve the bounding shape of a window.

--- a/src/x.c
+++ b/src/x.c
@@ -537,7 +537,7 @@ void x_clear_picture_clip_region(struct x_connection *c, xcb_render_picture_t pi
 void x_free_picture(struct x_connection *c, xcb_render_picture_t p) {
 	assert(p != XCB_NONE);
 	auto cookie = xcb_render_free_picture(c->c, p);
-	set_cant_fail_cookie(c, cookie);
+	set_debug_cant_fail_cookie(c, cookie);
 }
 
 enum {

--- a/src/x.c
+++ b/src/x.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include <X11/Xlib-xcb.h>
 #include <X11/Xutil.h>
 #include <pixman.h>
 #include <xcb/composite.h>
@@ -28,6 +29,72 @@
 #include "utils.h"
 #include "x.h"
 
+// === Error handling ===
+
+/**
+ * Xlib error handler function.
+ */
+static int xerror(Display attr_unused *dpy, XErrorEvent *ev) {
+	if (!ps_g) {
+		// Do not ignore errors until the session has been initialized
+		return 0;
+	}
+
+	// Fake a xcb error, fill in just enough information
+	xcb_generic_error_t xcb_err;
+	xcb_err.full_sequence = (uint32_t)ev->serial;
+	xcb_err.major_code = ev->request_code;
+	xcb_err.minor_code = ev->minor_code;
+	xcb_err.error_code = ev->error_code;
+	x_handle_error(&ps_g->c, &xcb_err);
+	return 0;
+}
+
+void x_discard_pending(struct x_connection *c, uint32_t sequence) {
+	while (c->pending_reply_head && sequence > c->pending_reply_head->sequence) {
+		auto next = c->pending_reply_head->next;
+		free(c->pending_reply_head);
+		c->pending_reply_head = next;
+	}
+	if (!c->pending_reply_head) {
+		c->pending_reply_tail = &c->pending_reply_head;
+	}
+}
+
+void x_handle_error(struct x_connection *c, xcb_generic_error_t *ev) {
+	x_discard_pending(c, ev->full_sequence);
+	if (c->pending_reply_head && c->pending_reply_head->sequence == ev->full_sequence) {
+		if (c->pending_reply_head->action != PENDING_REPLY_ACTION_IGNORE) {
+			x_log_error(LOG_LEVEL_ERROR, ev->full_sequence, ev->major_code,
+			            ev->minor_code, ev->error_code);
+		}
+		switch (c->pending_reply_head->action) {
+		case PENDING_REPLY_ACTION_ABORT:
+			log_fatal("An unrecoverable X error occurred, aborting...");
+			abort();
+		case PENDING_REPLY_ACTION_DEBUG_ABORT: assert(false); break;
+		case PENDING_REPLY_ACTION_IGNORE: break;
+		}
+		return;
+	}
+	x_log_error(LOG_LEVEL_WARN, ev->full_sequence, ev->major_code, ev->minor_code,
+	            ev->error_code);
+}
+
+/// Initialize x_connection struct from an Xlib Display.
+///
+/// Note this function doesn't take ownership of the Display, the caller is still
+/// responsible for closing it after `free_x_connection` is called.
+void x_connection_init(struct x_connection *c, Display *dpy) {
+	c->dpy = dpy;
+	c->c = XGetXCBConnection(dpy);
+	c->pending_reply_tail = &c->pending_reply_head;
+	c->previous_xerror_handler = XSetErrorHandler(xerror);
+
+	c->screen = DefaultScreen(dpy);
+	c->screen_info = x_screen_of_display(c, c->screen);
+}
+
 /**
  * Get a specific attribute of a window.
  *
@@ -43,11 +110,11 @@
  * @return a <code>winprop_t</code> structure containing the attribute
  *    and number of items. A blank one on failure.
  */
-winprop_t x_get_prop_with_offset(xcb_connection_t *c, xcb_window_t w, xcb_atom_t atom,
+winprop_t x_get_prop_with_offset(const struct x_connection *c, xcb_window_t w, xcb_atom_t atom,
                                  int offset, int length, xcb_atom_t rtype, int rformat) {
 	xcb_get_property_reply_t *r = xcb_get_property_reply(
-	    c,
-	    xcb_get_property(c, 0, w, atom, rtype, to_u32_checked(offset),
+	    c->c,
+	    xcb_get_property(c->c, 0, w, atom, rtype, to_u32_checked(offset),
 	                     to_u32_checked(length)),
 	    NULL);
 
@@ -71,10 +138,10 @@ winprop_t x_get_prop_with_offset(xcb_connection_t *c, xcb_window_t w, xcb_atom_t
 }
 
 /// Get the type, format and size in bytes of a window's specific attribute.
-winprop_info_t x_get_prop_info(xcb_connection_t *c, xcb_window_t w, xcb_atom_t atom) {
+winprop_info_t x_get_prop_info(const struct x_connection *c, xcb_window_t w, xcb_atom_t atom) {
 	xcb_generic_error_t *e = NULL;
 	auto r = xcb_get_property_reply(
-	    c, xcb_get_property(c, 0, w, atom, XCB_ATOM_ANY, 0, 0), &e);
+	    c->c, xcb_get_property(c->c, 0, w, atom, XCB_ATOM_ANY, 0, 0), &e);
 	if (!r) {
 		log_debug_x_error(e, "Failed to get property info for window %#010x", w);
 		free(e);
@@ -94,7 +161,7 @@ winprop_info_t x_get_prop_info(xcb_connection_t *c, xcb_window_t w, xcb_atom_t a
  *
  * @return the value if successful, 0 otherwise
  */
-xcb_window_t wid_get_prop_window(xcb_connection_t *c, xcb_window_t wid, xcb_atom_t aprop) {
+xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid, xcb_atom_t aprop) {
 	// Get the attribute
 	xcb_window_t p = XCB_NONE;
 	winprop_t prop = x_get_prop(c, wid, aprop, 1L, XCB_ATOM_WINDOW, 32);
@@ -115,7 +182,7 @@ xcb_window_t wid_get_prop_window(xcb_connection_t *c, xcb_window_t wid, xcb_atom
 bool wid_get_text_prop(session_t *ps, xcb_window_t wid, xcb_atom_t prop, char ***pstrlst,
                        int *pnstr) {
 	assert(ps->server_grabbed);
-	auto prop_info = x_get_prop_info(ps->c, wid, prop);
+	auto prop_info = x_get_prop_info(&ps->c, wid, prop);
 	auto type = prop_info.type;
 	auto format = prop_info.format;
 	auto length = prop_info.length;
@@ -140,7 +207,7 @@ bool wid_get_text_prop(session_t *ps, xcb_window_t wid, xcb_atom_t prop, char **
 	xcb_generic_error_t *e = NULL;
 	auto word_count = (length + 4 - 1) / 4;
 	auto r = xcb_get_property_reply(
-	    ps->c, xcb_get_property(ps->c, 0, wid, prop, type, 0, word_count), &e);
+	    ps->c.c, xcb_get_property(ps->c.c, 0, wid, prop, type, 0, word_count), &e);
 	if (!r) {
 		log_debug_x_error(e, "Failed to get window property for %#010x", wid);
 		free(e);
@@ -198,14 +265,14 @@ bool wid_get_text_prop(session_t *ps, xcb_window_t wid, xcb_atom_t prop, char **
 // of this program
 static thread_local xcb_render_query_pict_formats_reply_t *g_pictfmts = NULL;
 
-static inline void x_get_server_pictfmts(xcb_connection_t *c) {
+static inline void x_get_server_pictfmts(struct x_connection *c) {
 	if (g_pictfmts) {
 		return;
 	}
 	xcb_generic_error_t *e = NULL;
 	// Get window picture format
-	g_pictfmts =
-	    xcb_render_query_pict_formats_reply(c, xcb_render_query_pict_formats(c), &e);
+	g_pictfmts = xcb_render_query_pict_formats_reply(
+	    c->c, xcb_render_query_pict_formats(c->c), &e);
 	if (e || !g_pictfmts) {
 		log_fatal("failed to get pict formats\n");
 		abort();
@@ -213,7 +280,7 @@ static inline void x_get_server_pictfmts(xcb_connection_t *c) {
 }
 
 const xcb_render_pictforminfo_t *
-x_get_pictform_for_visual(xcb_connection_t *c, xcb_visualid_t visual) {
+x_get_pictform_for_visual(struct x_connection *c, xcb_visualid_t visual) {
 	x_get_server_pictfmts(c);
 
 	xcb_render_pictvisual_t *pv = xcb_render_util_find_visual_format(g_pictfmts, visual);
@@ -244,7 +311,7 @@ static xcb_visualid_t attr_pure x_get_visual_for_pictfmt(xcb_render_query_pict_f
 	return XCB_NONE;
 }
 
-xcb_visualid_t x_get_visual_for_standard(xcb_connection_t *c, xcb_pict_standard_t std) {
+xcb_visualid_t x_get_visual_for_standard(struct x_connection *c, xcb_pict_standard_t std) {
 	x_get_server_pictfmts(c);
 
 	auto pictfmt = xcb_render_util_find_standard_format(g_pictfmts, std);
@@ -253,7 +320,7 @@ xcb_visualid_t x_get_visual_for_standard(xcb_connection_t *c, xcb_pict_standard_
 }
 
 xcb_render_pictformat_t
-x_get_pictfmt_for_standard(xcb_connection_t *c, xcb_pict_standard_t std) {
+x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std) {
 	x_get_server_pictfmts(c);
 
 	auto pictfmt = xcb_render_util_find_standard_format(g_pictfmts, std);
@@ -261,8 +328,8 @@ x_get_pictfmt_for_standard(xcb_connection_t *c, xcb_pict_standard_t std) {
 	return pictfmt->id;
 }
 
-int x_get_visual_depth(xcb_connection_t *c, xcb_visualid_t visual) {
-	auto setup = xcb_get_setup(c);
+int x_get_visual_depth(struct x_connection *c, xcb_visualid_t visual) {
+	auto setup = xcb_get_setup(c->c);
 	for (auto screen = xcb_setup_roots_iterator(setup); screen.rem;
 	     xcb_screen_next(&screen)) {
 		for (auto depth = xcb_screen_allowed_depths_iterator(screen.data);
@@ -280,7 +347,7 @@ int x_get_visual_depth(xcb_connection_t *c, xcb_visualid_t visual) {
 }
 
 xcb_render_picture_t
-x_create_picture_with_pictfmt_and_pixmap(xcb_connection_t *c,
+x_create_picture_with_pictfmt_and_pixmap(struct x_connection *c,
                                          const xcb_render_pictforminfo_t *pictfmt,
                                          xcb_pixmap_t pixmap, uint32_t valuemask,
                                          const xcb_render_create_picture_value_list_t *attr) {
@@ -294,9 +361,9 @@ x_create_picture_with_pictfmt_and_pixmap(xcb_connection_t *c,
 	}
 
 	xcb_render_picture_t tmp_picture = x_new_id(c);
-	xcb_generic_error_t *e =
-	    xcb_request_check(c, xcb_render_create_picture_checked(
-	                             c, tmp_picture, pixmap, pictfmt->id, valuemask, buf));
+	xcb_generic_error_t *e = xcb_request_check(
+	    c->c, xcb_render_create_picture_checked(c->c, tmp_picture, pixmap,
+	                                            pictfmt->id, valuemask, buf));
 	free(buf);
 	if (e) {
 		log_error_x_error(e, "failed to create picture");
@@ -307,7 +374,7 @@ x_create_picture_with_pictfmt_and_pixmap(xcb_connection_t *c,
 }
 
 xcb_render_picture_t
-x_create_picture_with_visual_and_pixmap(xcb_connection_t *c, xcb_visualid_t visual,
+x_create_picture_with_visual_and_pixmap(struct x_connection *c, xcb_visualid_t visual,
                                         xcb_pixmap_t pixmap, uint32_t valuemask,
                                         const xcb_render_create_picture_value_list_t *attr) {
 	const xcb_render_pictforminfo_t *pictfmt = x_get_pictform_for_visual(c, visual);
@@ -315,7 +382,7 @@ x_create_picture_with_visual_and_pixmap(xcb_connection_t *c, xcb_visualid_t visu
 }
 
 xcb_render_picture_t
-x_create_picture_with_standard_and_pixmap(xcb_connection_t *c, xcb_pict_standard_t standard,
+x_create_picture_with_standard_and_pixmap(struct x_connection *c, xcb_pict_standard_t standard,
                                           xcb_pixmap_t pixmap, uint32_t valuemask,
                                           const xcb_render_create_picture_value_list_t *attr) {
 	x_get_server_pictfmts(c);
@@ -326,26 +393,26 @@ x_create_picture_with_standard_and_pixmap(xcb_connection_t *c, xcb_pict_standard
 }
 
 xcb_render_picture_t
-x_create_picture_with_standard(xcb_connection_t *c, xcb_drawable_t d, int w, int h,
+x_create_picture_with_standard(struct x_connection *c, int w, int h,
                                xcb_pict_standard_t standard, uint32_t valuemask,
                                const xcb_render_create_picture_value_list_t *attr) {
 	x_get_server_pictfmts(c);
 
 	auto pictfmt = xcb_render_util_find_standard_format(g_pictfmts, standard);
 	assert(pictfmt);
-	return x_create_picture_with_pictfmt(c, d, w, h, pictfmt, valuemask, attr);
+	return x_create_picture_with_pictfmt(c, w, h, pictfmt, valuemask, attr);
 }
 
 /**
  * Create an picture.
  */
 xcb_render_picture_t
-x_create_picture_with_pictfmt(xcb_connection_t *c, xcb_drawable_t d, int w, int h,
+x_create_picture_with_pictfmt(struct x_connection *c, int w, int h,
                               const xcb_render_pictforminfo_t *pictfmt, uint32_t valuemask,
                               const xcb_render_create_picture_value_list_t *attr) {
 	uint8_t depth = pictfmt->depth;
 
-	xcb_pixmap_t tmp_pixmap = x_create_pixmap(c, depth, d, w, h);
+	xcb_pixmap_t tmp_pixmap = x_create_pixmap(c, depth, w, h);
 	if (!tmp_pixmap) {
 		return XCB_NONE;
 	}
@@ -353,23 +420,23 @@ x_create_picture_with_pictfmt(xcb_connection_t *c, xcb_drawable_t d, int w, int 
 	xcb_render_picture_t picture = x_create_picture_with_pictfmt_and_pixmap(
 	    c, pictfmt, tmp_pixmap, valuemask, attr);
 
-	xcb_free_pixmap(c, tmp_pixmap);
+	set_cant_fail_cookie(c, xcb_free_pixmap(c->c, tmp_pixmap));
 
 	return picture;
 }
 
 xcb_render_picture_t
-x_create_picture_with_visual(xcb_connection_t *c, xcb_drawable_t d, int w, int h,
-                             xcb_visualid_t visual, uint32_t valuemask,
+x_create_picture_with_visual(struct x_connection *c, int w, int h, xcb_visualid_t visual,
+                             uint32_t valuemask,
                              const xcb_render_create_picture_value_list_t *attr) {
 	auto pictfmt = x_get_pictform_for_visual(c, visual);
-	return x_create_picture_with_pictfmt(c, d, w, h, pictfmt, valuemask, attr);
+	return x_create_picture_with_pictfmt(c, w, h, pictfmt, valuemask, attr);
 }
 
-bool x_fetch_region(xcb_connection_t *c, xcb_xfixes_region_t r, pixman_region32_t *res) {
+bool x_fetch_region(struct x_connection *c, xcb_xfixes_region_t r, pixman_region32_t *res) {
 	xcb_generic_error_t *e = NULL;
 	xcb_xfixes_fetch_region_reply_t *xr =
-	    xcb_xfixes_fetch_region_reply(c, xcb_xfixes_fetch_region(c, r), &e);
+	    xcb_xfixes_fetch_region_reply(c->c, xcb_xfixes_fetch_region(c->c, r), &e);
 	if (!xr) {
 		log_error_x_error(e, "Failed to fetch rectangles");
 		return false;
@@ -390,7 +457,7 @@ bool x_fetch_region(xcb_connection_t *c, xcb_xfixes_region_t r, pixman_region32_
 	return ret;
 }
 
-uint32_t x_create_region(xcb_connection_t *c, const region_t *reg) {
+uint32_t x_create_region(struct x_connection *c, const region_t *reg) {
 	if (!reg) {
 		return XCB_NONE;
 	}
@@ -410,8 +477,8 @@ uint32_t x_create_region(xcb_connection_t *c, const region_t *reg) {
 	}
 
 	xcb_xfixes_region_t ret = x_new_id(c);
-	bool success =
-	    XCB_AWAIT_VOID(xcb_xfixes_create_region, c, ret, to_u32_checked(nrects), xrects);
+	bool success = XCB_AWAIT_VOID(xcb_xfixes_create_region, c->c, ret,
+	                              to_u32_checked(nrects), xrects);
 	free(xrects);
 	if (!success) {
 		return XCB_NONE;
@@ -419,13 +486,13 @@ uint32_t x_create_region(xcb_connection_t *c, const region_t *reg) {
 	return ret;
 }
 
-void x_destroy_region(xcb_connection_t *c, xcb_xfixes_region_t r) {
+void x_destroy_region(struct x_connection *c, xcb_xfixes_region_t r) {
 	if (r != XCB_NONE) {
-		xcb_xfixes_destroy_region(c, r);
+		set_debug_cant_fail_cookie(c, xcb_xfixes_destroy_region(c->c, r));
 	}
 }
 
-void x_set_picture_clip_region(xcb_connection_t *c, xcb_render_picture_t pict,
+void x_set_picture_clip_region(struct x_connection *c, xcb_render_picture_t pict,
                                int16_t clip_x_origin, int16_t clip_y_origin,
                                const region_t *reg) {
 	int nrects;
@@ -440,9 +507,10 @@ void x_set_picture_clip_region(xcb_connection_t *c, xcb_render_picture_t pict,
 		};
 	}
 
-	xcb_generic_error_t *e = xcb_request_check(
-	    c, xcb_render_set_picture_clip_rectangles_checked(
-	           c, pict, clip_x_origin, clip_y_origin, to_u32_checked(nrects), xrects));
+	xcb_generic_error_t *e =
+	    xcb_request_check(c->c, xcb_render_set_picture_clip_rectangles_checked(
+	                                c->c, pict, clip_x_origin, clip_y_origin,
+	                                to_u32_checked(nrects), xrects));
 	if (e) {
 		log_error_x_error(e, "Failed to set clip region");
 		free(e);
@@ -450,15 +518,26 @@ void x_set_picture_clip_region(xcb_connection_t *c, xcb_render_picture_t pict,
 	free(xrects);
 }
 
-void x_clear_picture_clip_region(xcb_connection_t *c, xcb_render_picture_t pict) {
+void x_clear_picture_clip_region(struct x_connection *c, xcb_render_picture_t pict) {
 	assert(pict != XCB_NONE);
 	xcb_render_change_picture_value_list_t v = {.clipmask = XCB_NONE};
 	xcb_generic_error_t *e = xcb_request_check(
-	    c, xcb_render_change_picture_checked(c, pict, XCB_RENDER_CP_CLIP_MASK, &v));
+	    c->c, xcb_render_change_picture_checked(c->c, pict, XCB_RENDER_CP_CLIP_MASK, &v));
 	if (e) {
 		log_error_x_error(e, "failed to clear clip region");
 		free(e);
 	}
+}
+
+/**
+ * Destroy a <code>Picture</code>.
+ *
+ * Picture must be valid.
+ */
+void x_free_picture(struct x_connection *c, xcb_render_picture_t p) {
+	assert(p != XCB_NONE);
+	auto cookie = xcb_render_free_picture(c->c, p);
+	set_cant_fail_cookie(c, cookie);
 }
 
 enum {
@@ -593,12 +672,12 @@ const char *x_strerror(xcb_generic_error_t *e) {
 /**
  * Create a pixmap and check that creation succeeded.
  */
-xcb_pixmap_t x_create_pixmap(xcb_connection_t *c, uint8_t depth, xcb_drawable_t drawable,
-                             int width, int height) {
+xcb_pixmap_t x_create_pixmap(struct x_connection *c, uint8_t depth, int width, int height) {
 	xcb_pixmap_t pix = x_new_id(c);
-	xcb_void_cookie_t cookie = xcb_create_pixmap_checked(
-	    c, depth, pix, drawable, to_u16_checked(width), to_u16_checked(height));
-	xcb_generic_error_t *err = xcb_request_check(c, cookie);
+	xcb_void_cookie_t cookie =
+	    xcb_create_pixmap_checked(c->c, depth, pix, c->screen_info->root,
+	                              to_u16_checked(width), to_u16_checked(height));
+	xcb_generic_error_t *err = xcb_request_check(c->c, cookie);
 	if (err == NULL) {
 		return pix;
 	}
@@ -614,12 +693,12 @@ xcb_pixmap_t x_create_pixmap(xcb_connection_t *c, uint8_t depth, xcb_drawable_t 
  * Detect whether the pixmap is valid with XGetGeometry. Well, maybe there
  * are better ways.
  */
-bool x_validate_pixmap(xcb_connection_t *c, xcb_pixmap_t pixmap) {
+bool x_validate_pixmap(struct x_connection *c, xcb_pixmap_t pixmap) {
 	if (pixmap == XCB_NONE) {
 		return false;
 	}
 
-	auto r = xcb_get_geometry_reply(c, xcb_get_geometry(c, pixmap), NULL);
+	auto r = xcb_get_geometry_reply(c->c, xcb_get_geometry(c->c, pixmap), NULL);
 	if (!r) {
 		return false;
 	}
@@ -641,14 +720,14 @@ bool x_validate_pixmap(xcb_connection_t *c, xcb_pixmap_t pixmap) {
 /// https://github.com/ImageMagick/ImageMagick/blob/d04a47227637dbb3af9231b0107ccf9677bf985e/MagickCore/xwindow.c#L1853-L1922
 /// https://www.fvwm.org/Archive/Manpages/fvwm-root.html
 
-xcb_pixmap_t
-x_get_root_back_pixmap(xcb_connection_t *c, xcb_window_t root, struct atom *atoms) {
+xcb_pixmap_t x_get_root_back_pixmap(struct x_connection *c, struct atom *atoms) {
 	xcb_pixmap_t pixmap = XCB_NONE;
 
 	xcb_atom_t root_back_pixmap_atoms[] = {atoms->a_XROOTPMAP_ID, atoms->aESETROOT_PMAP_ID};
 	for (size_t i = 0; i < ARR_SIZE(root_back_pixmap_atoms); i++) {
 		winprop_t prop =
-		    x_get_prop(c, root, root_back_pixmap_atoms[i], 1, XCB_ATOM_PIXMAP, 32);
+		    x_get_prop(c, c->screen_info->root, root_back_pixmap_atoms[i], 1,
+		               XCB_ATOM_PIXMAP, 32);
 		if (prop.nitems) {
 			pixmap = (xcb_pixmap_t)*prop.p32;
 			free_winprop(&prop);
@@ -669,24 +748,24 @@ bool x_is_root_back_pixmap_atom(struct atom *atoms, xcb_atom_t atom) {
  * Synchronizes a X Render drawable to ensure all pending painting requests
  * are completed.
  */
-bool x_fence_sync(xcb_connection_t *c, xcb_sync_fence_t f) {
+bool x_fence_sync(struct x_connection *c, xcb_sync_fence_t f) {
 	// TODO(richardgv): If everybody just follows the rules stated in X Sync
 	// prototype, we need only one fence per screen, but let's stay a bit
 	// cautious right now
 
-	auto e = xcb_request_check(c, xcb_sync_trigger_fence_checked(c, f));
+	auto e = xcb_request_check(c->c, xcb_sync_trigger_fence_checked(c->c, f));
 	if (e) {
 		log_error_x_error(e, "Failed to trigger the fence");
 		goto err;
 	}
 
-	e = xcb_request_check(c, xcb_sync_await_fence_checked(c, 1, &f));
+	e = xcb_request_check(c->c, xcb_sync_await_fence_checked(c->c, 1, &f));
 	if (e) {
 		log_error_x_error(e, "Failed to await on a fence");
 		goto err;
 	}
 
-	e = xcb_request_check(c, xcb_sync_reset_fence_checked(c, f));
+	e = xcb_request_check(c->c, xcb_sync_reset_fence_checked(c->c, f));
 	if (e) {
 		log_error_x_error(e, "Failed to reset the fence");
 		goto err;
@@ -748,7 +827,7 @@ void x_create_convolution_kernel(const conv *kernel, double center,
 
 /// Generate a search criteria for fbconfig from a X visual.
 /// Returns {-1, -1, -1, -1, -1, 0} on failure
-struct xvisual_info x_get_visual_info(xcb_connection_t *c, xcb_visualid_t visual) {
+struct xvisual_info x_get_visual_info(struct x_connection *c, xcb_visualid_t visual) {
 	auto pictfmt = x_get_pictform_for_visual(c, visual);
 	auto depth = x_get_visual_depth(c, visual);
 	if (!pictfmt || depth == -1) {
@@ -776,10 +855,10 @@ struct xvisual_info x_get_visual_info(xcb_connection_t *c, xcb_visualid_t visual
 	};
 }
 
-xcb_screen_t *x_screen_of_display(xcb_connection_t *c, int screen) {
+xcb_screen_t *x_screen_of_display(struct x_connection *c, int screen) {
 	xcb_screen_iterator_t iter;
 
-	iter = xcb_setup_roots_iterator(xcb_get_setup(c));
+	iter = xcb_setup_roots_iterator(xcb_get_setup(c->c));
 	for (; iter.rem; --screen, xcb_screen_next(&iter)) {
 		if (screen == 0) {
 			return iter.data;
@@ -789,39 +868,34 @@ xcb_screen_t *x_screen_of_display(xcb_connection_t *c, int screen) {
 	return NULL;
 }
 
-void x_update_randr_monitors(session_t *ps) {
-	x_free_randr_info(ps);
-
-	if (!ps->o.crop_shadow_to_monitor || !ps->randr_exists) {
-		return;
-	}
+void x_update_monitors(struct x_connection *c, struct x_monitors *m) {
+	x_free_monitor_info(m);
 
 	xcb_randr_get_monitors_reply_t *r = xcb_randr_get_monitors_reply(
-	    ps->c, xcb_randr_get_monitors(ps->c, ps->root, true), NULL);
+	    c->c, xcb_randr_get_monitors(c->c, c->screen_info->root, true), NULL);
 	if (!r) {
 		return;
 	}
 
-	ps->randr_nmonitors = xcb_randr_get_monitors_monitors_length(r);
-	ps->randr_monitor_regs = ccalloc(ps->randr_nmonitors, region_t);
+	m->count = xcb_randr_get_monitors_monitors_length(r);
+	m->regions = ccalloc(m->count, region_t);
 	xcb_randr_monitor_info_iterator_t monitor_info_it =
 	    xcb_randr_get_monitors_monitors_iterator(r);
 	for (int i = 0; monitor_info_it.rem; xcb_randr_monitor_info_next(&monitor_info_it)) {
 		xcb_randr_monitor_info_t *mi = monitor_info_it.data;
-		pixman_region32_init_rect(&ps->randr_monitor_regs[i++], mi->x, mi->y,
-		                          mi->width, mi->height);
+		pixman_region32_init_rect(&m->regions[i++], mi->x, mi->y, mi->width, mi->height);
 	}
 
 	free(r);
 }
 
-void x_free_randr_info(session_t *ps) {
-	if (ps->randr_monitor_regs) {
-		for (int i = 0; i < ps->randr_nmonitors; i++) {
-			pixman_region32_fini(&ps->randr_monitor_regs[i]);
+void x_free_monitor_info(struct x_monitors *m) {
+	if (m->regions) {
+		for (int i = 0; i < m->count; i++) {
+			pixman_region32_fini(&m->regions[i]);
 		}
-		free(ps->randr_monitor_regs);
-		ps->randr_monitor_regs = NULL;
+		free(m->regions);
+		m->regions = NULL;
 	}
-	ps->randr_nmonitors = 0;
+	m->count = 0;
 }

--- a/src/x.h
+++ b/src/x.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2018 Yuxuan Shui <yshuiv7@gmail.com>
 #pragma once
+#include <X11/Xlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -55,6 +56,42 @@ struct xvisual_info {
 	xcb_visualid_t visual;
 };
 
+enum pending_reply_action {
+	PENDING_REPLY_ACTION_IGNORE,
+	PENDING_REPLY_ACTION_ABORT,
+	PENDING_REPLY_ACTION_DEBUG_ABORT,
+};
+
+typedef struct pending_reply {
+	struct pending_reply *next;
+	unsigned long sequence;
+	enum pending_reply_action action;
+} pending_reply_t;
+
+struct x_connection {
+	/// XCB connection.
+	xcb_connection_t *c;
+	/// Display in use.
+	Display *dpy;
+	/// Head pointer of the error ignore linked list.
+	pending_reply_t *pending_reply_head;
+	/// Pointer to the <code>next</code> member of tail element of the error
+	/// ignore linked list.
+	pending_reply_t **pending_reply_tail;
+	/// Previous handler of X errors
+	XErrorHandler previous_xerror_handler;
+	/// Default screen
+	int screen;
+	/// Information about the default screen
+	xcb_screen_t *screen_info;
+};
+
+/// Monitor info
+struct x_monitors {
+	int count;
+	region_t *regions;
+};
+
 #define XCB_AWAIT_VOID(func, c, ...)                                                     \
 	({                                                                               \
 		bool __success = true;                                                   \
@@ -92,8 +129,8 @@ struct xvisual_info {
 #define DOUBLE_TO_XFIXED(value) ((xcb_render_fixed_t)(((double)(value)) * 65536))
 
 /// Wraps x_new_id. abort the program if x_new_id returns error
-static inline uint32_t x_new_id(xcb_connection_t *c) {
-	auto ret = xcb_generate_id(c);
+static inline uint32_t x_new_id(struct x_connection *c) {
+	auto ret = xcb_generate_id(c->c);
 	if (ret == (uint32_t)-1) {
 		log_fatal("We seems to have run of XIDs. This is either a bug in the X "
 		          "server, or a resource leakage in the compositor. Please open "
@@ -103,6 +140,73 @@ static inline uint32_t x_new_id(xcb_connection_t *c) {
 	return ret;
 }
 
+static void set_reply_action(struct x_connection *c, uint32_t sequence,
+                             enum pending_reply_action action) {
+	auto i = cmalloc(pending_reply_t);
+
+	i->sequence = sequence;
+	i->next = 0;
+	i->action = action;
+	*c->pending_reply_tail = i;
+	c->pending_reply_tail = &i->next;
+}
+
+/**
+ * Ignore X errors caused by given X request.
+ */
+static inline void attr_unused set_ignore_cookie(struct x_connection *c,
+                                                 xcb_void_cookie_t cookie) {
+	set_reply_action(c, cookie.sequence, PENDING_REPLY_ACTION_IGNORE);
+}
+
+static inline void attr_unused set_cant_fail_cookie(struct x_connection *c,
+                                                    xcb_void_cookie_t cookie) {
+	set_reply_action(c, cookie.sequence, PENDING_REPLY_ACTION_ABORT);
+}
+
+static inline void attr_unused set_debug_cant_fail_cookie(struct x_connection *c,
+                                                          xcb_void_cookie_t cookie) {
+#ifndef NDEBUG
+	set_reply_action(c, cookie.sequence, PENDING_REPLY_ACTION_DEBUG_ABORT);
+#else
+	(void)c;
+	(void)cookie;
+#endif
+}
+
+static inline void attr_unused free_x_connection(struct x_connection *c) {
+	pending_reply_t *next = NULL;
+	for (auto ign = c->pending_reply_head; ign; ign = next) {
+		next = ign->next;
+
+		free(ign);
+	}
+
+	// Reset head and tail
+	c->pending_reply_head = NULL;
+	c->pending_reply_tail = &c->pending_reply_head;
+
+	XSetErrorHandler(c->previous_xerror_handler);
+}
+
+/// Initialize x_connection struct from an Xlib Display.
+///
+/// Note this function doesn't take ownership of the Display, the caller is still
+/// responsible for closing it after `free_x_connection` is called.
+void x_connection_init(struct x_connection *c, Display *dpy);
+
+/// Discard queued pending replies.
+///
+/// We have received reply with sequence number `sequence`, which means all pending
+/// replies with sequence number less than `sequence` will never be received. So discard
+/// them.
+void x_discard_pending(struct x_connection *c, uint32_t sequence);
+
+/// Handle X errors.
+///
+/// This function logs X errors, or aborts the program based on severity of the error.
+void x_handle_error(struct x_connection *c, xcb_generic_error_t *ev);
+
 /**
  * Send a request to X server and get the reply to make sure all previous
  * requests are processed, and their replies received
@@ -110,8 +214,8 @@ static inline uint32_t x_new_id(xcb_connection_t *c) {
  * xcb_get_input_focus is used here because it is the same request used by
  * libX11
  */
-static inline void x_sync(xcb_connection_t *c) {
-	free(xcb_get_input_focus_reply(c, xcb_get_input_focus(c), NULL));
+static inline void x_sync(struct x_connection *c) {
+	free(xcb_get_input_focus_reply(c->c, xcb_get_input_focus(c->c), NULL));
 }
 
 /**
@@ -129,25 +233,26 @@ static inline void x_sync(xcb_connection_t *c) {
  * @return a <code>winprop_t</code> structure containing the attribute
  *    and number of items. A blank one on failure.
  */
-winprop_t x_get_prop_with_offset(xcb_connection_t *c, xcb_window_t w, xcb_atom_t atom,
+winprop_t x_get_prop_with_offset(const struct x_connection *c, xcb_window_t w, xcb_atom_t atom,
                                  int offset, int length, xcb_atom_t rtype, int rformat);
 
 /**
  * Wrapper of wid_get_prop_adv().
  */
-static inline winprop_t x_get_prop(xcb_connection_t *c, xcb_window_t wid, xcb_atom_t atom,
-                                   int length, xcb_atom_t rtype, int rformat) {
+static inline winprop_t
+x_get_prop(const struct x_connection *c, xcb_window_t wid, xcb_atom_t atom, int length,
+           xcb_atom_t rtype, int rformat) {
 	return x_get_prop_with_offset(c, wid, atom, 0L, length, rtype, rformat);
 }
 
 /// Get the type, format and size in bytes of a window's specific attribute.
-winprop_info_t x_get_prop_info(xcb_connection_t *c, xcb_window_t w, xcb_atom_t atom);
+winprop_info_t x_get_prop_info(const struct x_connection *c, xcb_window_t w, xcb_atom_t atom);
 
 /// Discard all X events in queue or in flight. Should only be used when the server is
 /// grabbed
-static inline void x_discard_events(xcb_connection_t *c) {
+static inline void x_discard_events(struct x_connection *c) {
 	xcb_generic_event_t *e;
-	while ((e = xcb_poll_for_event(c))) {
+	while ((e = xcb_poll_for_event(c->c))) {
 		free(e);
 	}
 }
@@ -157,7 +262,7 @@ static inline void x_discard_events(xcb_connection_t *c) {
  *
  * @return the value if successful, 0 otherwise
  */
-xcb_window_t wid_get_prop_window(xcb_connection_t *c, xcb_window_t wid, xcb_atom_t aprop);
+xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid, xcb_atom_t aprop);
 
 /**
  * Get the value of a text property of a window.
@@ -170,30 +275,30 @@ bool wid_get_text_prop(session_t *ps, xcb_window_t wid, xcb_atom_t prop, char **
                        int *pnstr);
 
 const xcb_render_pictforminfo_t *
-x_get_pictform_for_visual(xcb_connection_t *, xcb_visualid_t);
-int x_get_visual_depth(xcb_connection_t *, xcb_visualid_t);
+x_get_pictform_for_visual(struct x_connection *, xcb_visualid_t);
+int x_get_visual_depth(struct x_connection *, xcb_visualid_t);
 
 xcb_render_picture_t
-x_create_picture_with_pictfmt_and_pixmap(xcb_connection_t *,
+x_create_picture_with_pictfmt_and_pixmap(struct x_connection *,
                                          const xcb_render_pictforminfo_t *pictfmt,
                                          xcb_pixmap_t pixmap, uint32_t valuemask,
                                          const xcb_render_create_picture_value_list_t *attr)
     attr_nonnull(1, 2);
 
 xcb_render_picture_t
-x_create_picture_with_visual_and_pixmap(xcb_connection_t *, xcb_visualid_t visual,
+x_create_picture_with_visual_and_pixmap(struct x_connection *, xcb_visualid_t visual,
                                         xcb_pixmap_t pixmap, uint32_t valuemask,
                                         const xcb_render_create_picture_value_list_t *attr)
     attr_nonnull(1);
 
 xcb_render_picture_t
-x_create_picture_with_standard_and_pixmap(xcb_connection_t *, xcb_pict_standard_t standard,
+x_create_picture_with_standard_and_pixmap(struct x_connection *, xcb_pict_standard_t standard,
                                           xcb_pixmap_t pixmap, uint32_t valuemask,
                                           const xcb_render_create_picture_value_list_t *attr)
     attr_nonnull(1);
 
 xcb_render_picture_t
-x_create_picture_with_standard(xcb_connection_t *c, xcb_drawable_t d, int w, int h,
+x_create_picture_with_standard(struct x_connection *c, int w, int h,
                                xcb_pict_standard_t standard, uint32_t valuemask,
                                const xcb_render_create_picture_value_list_t *attr)
     attr_nonnull(1);
@@ -202,30 +307,37 @@ x_create_picture_with_standard(xcb_connection_t *c, xcb_drawable_t d, int w, int
  * Create an picture.
  */
 xcb_render_picture_t
-x_create_picture_with_pictfmt(xcb_connection_t *, xcb_drawable_t, int w, int h,
+x_create_picture_with_pictfmt(struct x_connection *, int w, int h,
                               const xcb_render_pictforminfo_t *pictfmt, uint32_t valuemask,
                               const xcb_render_create_picture_value_list_t *attr)
-    attr_nonnull(1, 5);
+    attr_nonnull(1, 4);
 
 xcb_render_picture_t
-x_create_picture_with_visual(xcb_connection_t *, xcb_drawable_t, int w, int h,
-                             xcb_visualid_t visual, uint32_t valuemask,
+x_create_picture_with_visual(struct x_connection *, int w, int h, xcb_visualid_t visual,
+                             uint32_t valuemask,
                              const xcb_render_create_picture_value_list_t *attr)
     attr_nonnull(1);
 
 /// Fetch a X region and store it in a pixman region
-bool x_fetch_region(xcb_connection_t *, xcb_xfixes_region_t r, region_t *res);
+bool x_fetch_region(struct x_connection *, xcb_xfixes_region_t r, region_t *res);
 
 /// Create a X region from a pixman region
-uint32_t x_create_region(xcb_connection_t *c, const region_t *reg);
+uint32_t x_create_region(struct x_connection *c, const region_t *reg);
 
 /// Destroy a X region
-void x_destroy_region(xcb_connection_t *c, uint32_t region);
+void x_destroy_region(struct x_connection *c, uint32_t region);
 
-void x_set_picture_clip_region(xcb_connection_t *, xcb_render_picture_t, int16_t clip_x_origin,
-                               int16_t clip_y_origin, const region_t *);
+void x_set_picture_clip_region(struct x_connection *, xcb_render_picture_t,
+                               int16_t clip_x_origin, int16_t clip_y_origin, const region_t *);
 
-void x_clear_picture_clip_region(xcb_connection_t *, xcb_render_picture_t pict);
+void x_clear_picture_clip_region(struct x_connection *, xcb_render_picture_t pict);
+
+/**
+ * Destroy a <code>Picture</code>.
+ *
+ * Picture must be valid.
+ */
+void x_free_picture(struct x_connection *c, xcb_render_picture_t p);
 
 /**
  * Log a X11 error
@@ -242,10 +354,9 @@ void x_log_error(enum log_level level, unsigned long serial, uint8_t major,
  */
 const char *x_strerror(xcb_generic_error_t *e);
 
-xcb_pixmap_t x_create_pixmap(xcb_connection_t *, uint8_t depth, xcb_drawable_t drawable,
-                             int width, int height);
+xcb_pixmap_t x_create_pixmap(struct x_connection *, uint8_t depth, int width, int height);
 
-bool x_validate_pixmap(xcb_connection_t *, xcb_pixmap_t pxmap);
+bool x_validate_pixmap(struct x_connection *, xcb_pixmap_t pxmap);
 
 /**
  * Free a <code>winprop_t</code>.
@@ -254,22 +365,22 @@ bool x_validate_pixmap(xcb_connection_t *, xcb_pixmap_t pxmap);
  */
 static inline void free_winprop(winprop_t *pprop) {
 	// Empty the whole structure to avoid possible issues
-	if (pprop->r)
+	if (pprop->r) {
 		free(pprop->r);
+	}
 	pprop->ptr = NULL;
 	pprop->r = NULL;
 	pprop->nitems = 0;
 }
 
 /// Get the back pixmap of the root window
-xcb_pixmap_t
-x_get_root_back_pixmap(xcb_connection_t *c, xcb_window_t root, struct atom *atoms);
+xcb_pixmap_t x_get_root_back_pixmap(struct x_connection *c, struct atom *atoms);
 
 /// Return true if the atom refers to a property name that is used for the
 /// root window background pixmap
 bool x_is_root_back_pixmap_atom(struct atom *atoms, xcb_atom_t atom);
 
-bool x_fence_sync(xcb_connection_t *, xcb_sync_fence_t);
+bool x_fence_sync(struct x_connection *, xcb_sync_fence_t);
 
 struct x_convolution_kernel {
 	int size;
@@ -293,23 +404,18 @@ void attr_nonnull(1, 3) x_create_convolution_kernel(const conv *kernel, double c
 
 /// Generate a search criteria for fbconfig from a X visual.
 /// Returns {-1, -1, -1, -1, -1, -1} on failure
-struct xvisual_info x_get_visual_info(xcb_connection_t *c, xcb_visualid_t visual);
+struct xvisual_info x_get_visual_info(struct x_connection *c, xcb_visualid_t visual);
 
-xcb_visualid_t x_get_visual_for_standard(xcb_connection_t *c, xcb_pict_standard_t std);
+xcb_visualid_t x_get_visual_for_standard(struct x_connection *c, xcb_pict_standard_t std);
 
 xcb_render_pictformat_t
-x_get_pictfmt_for_standard(xcb_connection_t *c, xcb_pict_standard_t std);
+x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std);
 
-xcb_screen_t *x_screen_of_display(xcb_connection_t *c, int screen);
+xcb_screen_t *x_screen_of_display(struct x_connection *c, int screen);
 
-/**
- * X RandR-related functions.
- *
- * The x_update_randr_monitors function populates ps->randr_nmonitors and
- * ps->randr_monitor_regs with the data X RandR provided and the
- * x_free_randr_info function frees them.
- */
-void x_update_randr_monitors(session_t *ps);
-void x_free_randr_info(session_t *ps);
+/// Populates a `struct x_monitors` with the current monitor configuration.
+void x_update_monitors(struct x_connection *, struct x_monitors *);
+/// Free memory allocated for a `struct x_monitors`.
+void x_free_monitor_info(struct x_monitors *);
 
 uint32_t attr_deprecated xcb_generate_id(xcb_connection_t *c);


### PR DESCRIPTION
Part of the long running effort to reduce the prevalence of `session_t`. After this, functions that communicate with X can make use of the error handling machinary (set_ignore_cookie, set_cant_fail_cookie) without needing to take a `session_t` parameter.

This commit converts everything to use the new struct `x_connection`, most of the conversions are mechanical.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
