### PR TITLE
Implement root_change

### DIFF
--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -366,6 +366,7 @@ static void egl_diagnostics(backend_t *base) {
 struct backend_operations egl_ops = {
     .init = egl_init,
     .deinit = egl_deinit,
+    .root_change = gl_root_change,
     .bind_pixmap = egl_bind_pixmap,
     .release_image = gl_release_image,
     .prepare = gl_prepare,

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -621,6 +621,11 @@ static bool gl_win_shader_from_stringv(const char **vshader_strv,
 	return true;
 }
 
+void gl_root_change(backend_t *base, session_t *ps) {
+	auto gd = (struct gl_data *)base;
+	gl_resize(gd, ps->root_width, ps->root_height);
+}
+
 /**
  * Callback to run on root window size change.
  */

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -153,6 +153,8 @@ bool gl_last_render_time(backend_t *backend_data, struct timespec *time);
 void gl_compose(backend_t *, image_handle image, coord_t image_dst, image_handle mask,
                 coord_t mask_dst, const region_t *reg_tgt, const region_t *reg_visible);
 
+void gl_root_change(backend_t *base, session_t *);
+
 void gl_resize(struct gl_data *, int width, int height);
 
 bool gl_init(struct gl_data *gd, session_t *);

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -547,6 +547,7 @@ static void glx_diagnostics(backend_t *base) {
 struct backend_operations glx_ops = {
     .init = glx_init,
     .deinit = glx_deinit,
+    .root_change = gl_root_change,
     .bind_pixmap = glx_bind_pixmap,
     .release_image = gl_release_image,
     .prepare = gl_prepare,


### PR DESCRIPTION
This also fixes the crash when the root window size has changed which caused the backend to be destroyed.