### PR TITLE
small dual kawase optimizations

### DIFF
--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -195,6 +195,15 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 
 	glUniform2f(up_pass->texorig_loc, (GLfloat)extent->x1, (GLfloat)dst_y_fb_coord);
 
+	glActiveTexture(GL_TEXTURE1);
+	glBindTexture(GL_TEXTURE_2D, default_mask);
+
+	glUniform1i(up_pass->uniform_mask_tex, 1);
+	glUniform2f(up_pass->uniform_mask_offset, 0.0F, 0.0F);
+	glUniform1i(up_pass->uniform_mask_inverted, 0);
+	glUniform1f(up_pass->uniform_mask_corner_radius, 0.0F);
+	glUniform1f(up_pass->uniform_opacity, 1.0F);
+
 	for (int i = iterations - 1; i >= 0; --i) {
 		// Scale output width / height back by two in each iteration
 		scale_factor >>= 1;
@@ -209,21 +218,13 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, src_texture);
-		glActiveTexture(GL_TEXTURE1);
-		glBindTexture(GL_TEXTURE_2D, default_mask);
 
-		glUniform1i(up_pass->uniform_mask_tex, 1);
-		glUniform2f(up_pass->uniform_mask_offset, 0.0F, 0.0F);
-		glUniform1i(up_pass->uniform_mask_inverted, 0);
-		glUniform1f(up_pass->uniform_mask_corner_radius, 0.0F);
 		if (i > 0) {
 			assert(bctx->blur_fbos[i - 1]);
 
 			// not last pass, draw into next framebuffer
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[i - 1]);
 			glDrawBuffer(GL_COLOR_ATTACHMENT0);
-
-			glUniform1f(up_pass->uniform_opacity, (GLfloat)1);
 		} else {
 			// last pass, draw directly into the back buffer
 			if (mask) {

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -150,6 +150,9 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 
 	glUniform2f(down_pass->texorig_loc, (GLfloat)extent->x1, (GLfloat)dst_y_fb_coord);
 
+	glBindVertexArray(vao[1]);
+	int nelems = vao_nelems[1];
+
 	for (int i = 0; i < iterations; ++i) {
 		// Scale output width / height by half in each iteration
 		scale_factor <<= 1;
@@ -174,8 +177,6 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 		assert(bctx->blur_fbos[i]);
 
 		glBindTexture(GL_TEXTURE_2D, src_texture);
-		glBindVertexArray(vao[1]);
-		auto nelems = vao_nelems[1];
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[i]);
 		glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
@@ -206,9 +207,6 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 		int tex_width = src_size.width;
 		int tex_height = src_size.height;
 
-		// The number of indices in the selected vertex array
-		GLsizei nelems;
-
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, src_texture);
 		glActiveTexture(GL_TEXTURE1);
@@ -222,8 +220,6 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 			assert(bctx->blur_fbos[i - 1]);
 
 			// not last pass, draw into next framebuffer
-			glBindVertexArray(vao[1]);
-			nelems = vao_nelems[1];
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[i - 1]);
 			glDrawBuffer(GL_COLOR_ATTACHMENT0);
 


### PR DESCRIPTION
52 opengl calls per frame less with my configuration on the same scene according to apitrace:
![image](https://github.com/yshui/picom/assets/52252283/b19d190d-700e-4aba-9928-92350deb6c11)