### PR TITLE
config: drop kawase blur method

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -191,11 +191,6 @@ enum blur_method parse_blur_method(const char *src) {
 		return BLUR_METHOD_GAUSSIAN;
 	} else if (strcmp(src, "dual_kawase") == 0) {
 		return BLUR_METHOD_DUAL_KAWASE;
-	} else if (strcmp(src, "kawase") == 0) {
-		log_warn("Blur method 'kawase' has been renamed to 'dual_kawase'. "
-		         "Interpreted as 'dual_kawase', but this will stop working "
-		         "soon.");
-		return BLUR_METHOD_DUAL_KAWASE;
 	} else if (strcmp(src, "none") == 0) {
 		return BLUR_METHOD_NONE;
 	}

--- a/src/config.c
+++ b/src/config.c
@@ -183,15 +183,19 @@ const char *parse_readnum(const char *src, double *dest) {
 }
 
 enum blur_method parse_blur_method(const char *src) {
+	if (strcmp(src, "box") == 0) {
+		return BLUR_METHOD_BOX;
+	}
+	if (strcmp(src, "dual_kawase") == 0) {
+		return BLUR_METHOD_DUAL_KAWASE;
+	}
+	if (strcmp(src, "gaussian") == 0) {
+		return BLUR_METHOD_GAUSSIAN;
+	}
 	if (strcmp(src, "kernel") == 0) {
 		return BLUR_METHOD_KERNEL;
-	} else if (strcmp(src, "box") == 0) {
-		return BLUR_METHOD_BOX;
-	} else if (strcmp(src, "gaussian") == 0) {
-		return BLUR_METHOD_GAUSSIAN;
-	} else if (strcmp(src, "dual_kawase") == 0) {
-		return BLUR_METHOD_DUAL_KAWASE;
-	} else if (strcmp(src, "none") == 0) {
+	}
+	if (strcmp(src, "none") == 0) {
 		return BLUR_METHOD_NONE;
 	}
 	return BLUR_METHOD_INVALID;


### PR DESCRIPTION
### config: drop kawase blur method

it was added with intention to remove it later almost three years ago in
33c5a5a36b1ccf1da72a9e95079dcc4e3713dce9

### config: refactor the parse_blur_method function

sort blur methods alphabetically and address some clang-tidy issues