### PR TITLE
backend: make target window a parameter of the init backend operation

### DIFF
--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -119,11 +119,7 @@ struct backend_operations {
 	// ===========    Initialization    ===========
 
 	/// Initialize the backend, prepare for rendering to the target window.
-	/// Here is how you should choose target window:
-	///    1) if ps->overlay is not XCB_NONE, use that
-	///    2) use ps->root otherwise
-	// TODO(yshui) make the target window a parameter
-	backend_t *(*init)(session_t *)attr_nonnull(1);
+	backend_t *(*init)(session_t *, xcb_window_t)attr_nonnull(1);
 	void (*deinit)(backend_t *backend_data) attr_nonnull(1);
 
 	/// Called when rendering will be stopped for an unknown amount of

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -28,8 +28,7 @@ struct dummy_data {
 	struct backend_image mask;
 };
 
-struct backend_base *
-dummy_init(struct session *ps attr_unused, xcb_window_t target attr_unused) {
+struct backend_base *dummy_init(session_t *ps attr_unused, xcb_window_t target attr_unused) {
 	auto ret = (struct backend_base *)ccalloc(1, struct dummy_data);
 	ret->c = &ps->c;
 	ret->loop = ps->loop;

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -28,7 +28,8 @@ struct dummy_data {
 	struct backend_image mask;
 };
 
-struct backend_base *dummy_init(struct session *ps attr_unused) {
+struct backend_base *
+dummy_init(struct session *ps attr_unused, xcb_window_t target attr_unused) {
 	auto ret = (struct backend_base *)ccalloc(1, struct dummy_data);
 	ret->c = &ps->c;
 	ret->loop = ps->loop;

--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -211,8 +211,8 @@ static backend_t *egl_init(session_t *ps, xcb_window_t target) {
 	}
 	// clang-format on
 
-	gd->target_win = eglCreatePlatformWindowSurfaceProc(
-	    gd->display, config, (xcb_window_t[]){target}, NULL);
+	gd->target_win =
+	    eglCreatePlatformWindowSurfaceProc(gd->display, config, &target, NULL);
 	if (gd->target_win == EGL_NO_SURFACE) {
 		log_error("Failed to create EGL surface.");
 		goto end;

--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -130,7 +130,7 @@ static bool egl_set_swap_interval(int interval, EGLDisplay dpy) {
 /**
  * Initialize OpenGL.
  */
-static backend_t *egl_init(session_t *ps) {
+static backend_t *egl_init(session_t *ps, xcb_window_t target) {
 	bool success = false;
 	struct egl_data *gd = NULL;
 
@@ -212,7 +212,7 @@ static backend_t *egl_init(session_t *ps) {
 	// clang-format on
 
 	gd->target_win = eglCreatePlatformWindowSurfaceProc(
-	    gd->display, config, (xcb_window_t[]){session_get_target_window(ps)}, NULL);
+	    gd->display, config, (xcb_window_t[]){target}, NULL);
 	if (gd->target_win == EGL_NO_SURFACE) {
 		log_error("Failed to create EGL surface.");
 		goto end;

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -227,13 +227,13 @@ static bool glx_set_swap_interval(int interval, Display *dpy, GLXDrawable drawab
 /**
  * Initialize OpenGL.
  */
-static backend_t *glx_init(session_t *ps) {
+static backend_t *glx_init(session_t *ps, xcb_window_t target) {
 	bool success = false;
 	glxext_init(ps->c.dpy, ps->c.screen);
 	auto gd = ccalloc(1, struct _glx_data);
 	init_backend_base(&gd->gl.base, ps);
 
-	gd->target_win = session_get_target_window(ps);
+	gd->target_win = target;
 
 	XVisualInfo *pvis = NULL;
 

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -869,7 +869,7 @@ static void get_blur_size(void *blur_context, int *width, int *height) {
 	*height = ctx->resize_height;
 }
 
-static backend_t *backend_xrender_init(session_t *ps) {
+static backend_t *backend_xrender_init(session_t *ps, xcb_window_t target) {
 	if (ps->o.dithered_present) {
 		log_warn("\"dithered-present\" is not supported by the xrender backend.");
 	}
@@ -888,7 +888,7 @@ static backend_t *backend_xrender_init(session_t *ps) {
 	xd->black_pixel = solid_picture(&ps->c, true, 1, 0, 0, 0);
 	xd->white_pixel = solid_picture(&ps->c, true, 1, 1, 1, 1);
 
-	xd->target_win = session_get_target_window(ps);
+	xd->target_win = target;
 	xcb_render_create_picture_value_list_t pa = {
 	    .subwindowmode = XCB_SUBWINDOW_MODE_INCLUDE_INFERIORS,
 	};

--- a/src/diagnostic.c
+++ b/src/diagnostic.c
@@ -39,7 +39,7 @@ void print_diagnostics(session_t *ps, const char *config_file, bool compositor_r
 	for (int i = 0; i < NUM_BKEND; i++) {
 		if (backend_list[i] && backend_list[i]->diagnostics) {
 			printf("\n### Backend: %s\n\n", BACKEND_STRS[i]);
-			auto data = backend_list[i]->init(ps);
+			auto data = backend_list[i]->init(ps, session_get_target_window(ps));
 			if (!data) {
 				printf(" Cannot initialize this backend\n");
 			} else {

--- a/src/picom.c
+++ b/src/picom.c
@@ -605,7 +605,8 @@ static bool initialize_backend(session_t *ps) {
 		assert(!ps->backend_data);
 		// Reinitialize win_data
 		assert(backend_list[ps->o.backend]);
-		ps->backend_data = backend_list[ps->o.backend]->init(ps);
+		ps->backend_data =
+		    backend_list[ps->o.backend]->init(ps, session_get_target_window(ps));
 		if (!ps->backend_data) {
 			log_fatal("Failed to initialize backend, aborting...");
 			quit(ps);


### PR DESCRIPTION
### backend: make target window a parameter of the init backend operation
to address a todo

### backend: egl: simplify usage of the target window parameter in egl_init

### backend: dummy: change type of ps parameter to session_t in dummy_init