### PR TITLE
picom.desktop: Hide from menus by default

### DIFF
--- a/picom.desktop
+++ b/picom.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-NoDisplay=false
+NoDisplay=true
 Name=picom
 GenericName=X compositor
 Comment=An X compositor


### PR DESCRIPTION
Like the Compton desktop file, this desktop entry should be marked as hidden by default because it's intended to be configured and started as part of the X11 environment.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
