### PR TITLE
backend: xrender: cache the present region

### DIFF
--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -56,6 +56,10 @@ typedef struct _xrender_data {
 	int target_width, target_height;
 
 	xcb_special_event_t *present_event;
+
+	/// Cache an X region to avoid creating and destroying it every frame. A
+	/// workaround for yshui/picom#1166.
+	xcb_xfixes_region_t present_region;
 } xrender_data;
 
 struct _xrender_blur_context {
@@ -597,6 +601,7 @@ static void deinit(backend_t *backend_data) {
 			xcb_free_pixmap(xd->base.c->c, xd->back_pixmap[i]);
 		}
 	}
+	x_destroy_region(xd->base.c, xd->present_region);
 	if (xd->present_event) {
 		xcb_unregister_for_special_event(xd->base.c->c, xd->present_event);
 	}
@@ -624,16 +629,15 @@ static void present(backend_t *base, const region_t *region) {
 		                     XCB_NONE, xd->back[xd->curr_back], orig_x, orig_y, 0,
 		                     0, orig_x, orig_y, region_width, region_height);
 
-		auto xregion = x_create_region(base->c, region);
-
 		// Make sure we got reply from PresentPixmap before waiting for events,
 		// to avoid deadlock
 		auto e = xcb_request_check(
-		    base->c->c, xcb_present_pixmap_checked(
-		                    xd->base.c->c, xd->target_win,
-		                    xd->back_pixmap[xd->curr_back], 0, XCB_NONE, xregion, 0,
-		                    0, XCB_NONE, XCB_NONE, XCB_NONE, 0, 0, 0, 0, 0, NULL));
-		x_destroy_region(base->c, xregion);
+		    base->c->c,
+		    xcb_present_pixmap_checked(
+		        base->c->c, xd->target_win, xd->back_pixmap[xd->curr_back], 0, XCB_NONE,
+		        x_set_region(base->c, xd->present_region, region) ? xd->present_region
+		                                                          : XCB_NONE,
+		        0, 0, XCB_NONE, XCB_NONE, XCB_NONE, 0, 0, 0, 0, 0, NULL));
 		if (e) {
 			log_error("Failed to present pixmap");
 			free(e);
@@ -927,6 +931,10 @@ static backend_t *backend_xrender_init(session_t *ps, xcb_window_t target) {
 		}
 	} else {
 		xd->vsync = false;
+	}
+
+	if (xd->vsync) {
+		xd->present_region = x_create_region(&ps->c, &ps->screen_reg);
 	}
 
 	// We might need to do double buffering for vsync, and buffer 0 and 1 are for

--- a/src/x.h
+++ b/src/x.h
@@ -321,6 +321,9 @@ x_create_picture_with_visual(struct x_connection *, int w, int h, xcb_visualid_t
 /// Fetch a X region and store it in a pixman region
 bool x_fetch_region(struct x_connection *, xcb_xfixes_region_t r, region_t *res);
 
+/// Set an X region to a pixman region
+bool x_set_region(struct x_connection *c, xcb_xfixes_region_t dst, const region_t *src);
+
 /// Create a X region from a pixman region
 uint32_t x_create_region(struct x_connection *c, const region_t *reg);
 


### PR DESCRIPTION
a workaround for #1166. it doesn't fix the underlying issue (that's not known and needs to be investigated and ideally fixed) but reduces the probability of it's appearance. lmk if i got too paranoid with various checks and some of them are not really needed :sweat_smile:

### x: add the x_set_region function
it sets an x region to a pixman region

### backend: xrender: cache the present region
to avoid creating and destroying it every frame