### PR TITLE
vblank: reset SGI_video_sync scheduler if it's getting nonsense (because of nvidia)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Allow `corner-radius-rules` to override `corner-radius = 0`. Previously setting corner radius to 0 globally disables rounded corners. (#1170)
 
+## Bug fixes
+
+* Workaround a NVIDIA problem that causes high CPU usage after suspend/resume (#1172, #1168)
+
 # v11.1 (2024-Jan-28)
 
 ## Bug fixes


### PR DESCRIPTION
If resetting fails, set a flag so all future schedule calls will fail.

Fixes #1168

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
