### PR TITLE
Update README.md (Fedora Build Dependencies) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ libconfig-dev libdbus-1-dev libegl-dev libev-dev libgl-dev libpcre2-dev libpixma
 On Fedora, the needed packages are
 
 ```
-dbus-devel gcc git libconfig-devel libdrm-devel libev-devel libX11-devel libX11-xcb libXext-devel libxcb-devel libGL-devel libEGL-devel meson pcre2-devel pixman-devel uthash-devel xcb-util-image-devel xcb-util-renderutil-devel xorg-x11-proto-devel
+dbus-devel gcc git libconfig-devel libdrm-devel libev-devel libX11-devel libX11-xcb libXext-devel libxcb-devel libGL-devel libEGL-devel meson pcre2-devel pixman-devel uthash-devel xcb-util-image-devel xcb-util-renderutil-devel xorg-x11-proto-devel xcb-util-devel
 ```
 
 To build the documents, you need `asciidoc`


### PR DESCRIPTION
Hey 👋🏾, 

This is my first time doing something like this.

I was trying to build picom on Fedora and the `meson setup build` failed as the `xcb-util-devel` package was missing.

Updated README.md to include xcb-util-devel package for fedora build dependencies.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
