### PR TITLE
backend: give images a type

### DIFF
--- a/src/backend/backend_common.c
+++ b/src/backend/backend_common.c
@@ -293,8 +293,8 @@ shadow_picture_err:
 	return false;
 }
 
-void *default_render_shadow(backend_t *backend_data, int width, int height,
-                            struct backend_shadow_context *sctx, struct color color) {
+image_handle default_render_shadow(backend_t *backend_data, int width, int height,
+                                   struct backend_shadow_context *sctx, struct color color) {
 	const conv *kernel = (void *)sctx;
 	xcb_render_picture_t shadow_pixel =
 	    solid_picture(backend_data->c, true, 1, color.red, color.green, color.blue);
@@ -308,7 +308,7 @@ void *default_render_shadow(backend_t *backend_data, int width, int height,
 	}
 
 	auto visual = x_get_visual_for_standard(backend_data->c, XCB_PICT_STANDARD_ARGB_32);
-	void *ret = backend_data->ops->bind_pixmap(
+	auto ret = backend_data->ops->bind_pixmap(
 	    backend_data, shadow, x_get_visual_info(backend_data->c, visual), true);
 	x_free_picture(backend_data->c, pict);
 	x_free_picture(backend_data->c, shadow_pixel);
@@ -316,16 +316,16 @@ void *default_render_shadow(backend_t *backend_data, int width, int height,
 }
 
 /// Implement render_shadow with shadow_from_mask
-void *
+image_handle
 backend_render_shadow_from_mask(backend_t *backend_data, int width, int height,
                                 struct backend_shadow_context *sctx, struct color color) {
 	region_t reg;
 	pixman_region32_init_rect(&reg, 0, 0, (unsigned int)width, (unsigned int)height);
-	void *mask = backend_data->ops->make_mask(
+	auto mask = backend_data->ops->make_mask(
 	    backend_data, (geometry_t){.width = width, .height = height}, &reg);
 	pixman_region32_fini(&reg);
 
-	void *shadow = backend_data->ops->shadow_from_mask(backend_data, mask, sctx, color);
+	auto shadow = backend_data->ops->shadow_from_mask(backend_data, mask, sctx, color);
 	backend_data->ops->release_image(backend_data, mask);
 	return shadow;
 }
@@ -458,17 +458,17 @@ struct dual_kawase_params *generate_dual_kawase_params(void *args) {
 	return params;
 }
 
-void *default_clone_image(backend_t *base attr_unused, const void *image_data,
-                          const region_t *reg_visible attr_unused) {
+image_handle default_clone_image(backend_t *base attr_unused, image_handle image,
+                                 const region_t *reg_visible attr_unused) {
 	auto new_img = ccalloc(1, struct backend_image);
-	*new_img = *(struct backend_image *)image_data;
+	*new_img = *(struct backend_image *)image;
 	new_img->inner->refcount++;
-	return new_img;
+	return (image_handle)new_img;
 }
 
 bool default_set_image_property(backend_t *base attr_unused, enum image_properties op,
-                                void *image_data, void *arg) {
-	struct backend_image *tex = image_data;
+                                image_handle image, void *arg) {
+	auto tex = (struct backend_image *)image;
 	int *iargs = arg;
 	bool *bargs = arg;
 	double *dargs = arg;
@@ -490,8 +490,8 @@ bool default_set_image_property(backend_t *base attr_unused, enum image_properti
 	return true;
 }
 
-bool default_is_image_transparent(backend_t *base attr_unused, void *image_data) {
-	struct backend_image *img = image_data;
+bool default_is_image_transparent(backend_t *base attr_unused, image_handle image) {
+	auto img = (struct backend_image *)image;
 	return img->opacity < 1 || img->inner->has_alpha;
 }
 

--- a/src/backend/backend_common.h
+++ b/src/backend/backend_common.h
@@ -54,11 +54,11 @@ solid_picture(struct x_connection *, bool argb, double a, double r, double g, do
 xcb_image_t *make_shadow(struct x_connection *c, const conv *kernel, double opacity,
                          int width, int height);
 
-void *default_render_shadow(backend_t *backend_data, int width, int height,
-                            struct backend_shadow_context *sctx, struct color color);
+image_handle default_render_shadow(backend_t *backend_data, int width, int height,
+                                   struct backend_shadow_context *sctx, struct color color);
 
 /// Implement `render_shadow` with `shadow_from_mask`.
-void *
+image_handle
 backend_render_shadow_from_mask(backend_t *backend_data, int width, int height,
                                 struct backend_shadow_context *sctx, struct color color);
 struct backend_shadow_context *
@@ -72,8 +72,8 @@ void init_backend_base(struct backend_base *base, session_t *ps);
 struct conv **generate_blur_kernel(enum blur_method method, void *args, int *kernel_count);
 struct dual_kawase_params *generate_dual_kawase_params(void *args);
 
-void *default_clone_image(backend_t *base, const void *image_data, const region_t *reg);
-bool default_is_image_transparent(backend_t *base attr_unused, void *image_data);
+image_handle default_clone_image(backend_t *base, image_handle image, const region_t *reg);
+bool default_is_image_transparent(backend_t *base attr_unused, image_handle image);
 bool default_set_image_property(backend_t *base attr_unused, enum image_properties op,
-                                void *image_data, void *arg);
+                                image_handle image, void *arg);
 struct backend_image *default_new_backend_image(int w, int h);

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -256,10 +256,11 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx, const rec
 	return true;
 }
 
-bool gl_blur_impl(double opacity, struct gl_blur_context *bctx, void *mask, coord_t mask_dst,
-                  const region_t *reg_blur, const region_t *reg_visible attr_unused,
-                  GLuint source_texture, geometry_t source_size, GLuint target_fbo,
-                  GLuint default_mask, bool high_precision) {
+bool gl_blur_impl(double opacity, struct gl_blur_context *bctx,
+                  struct backend_image *mask, coord_t mask_dst, const region_t *reg_blur,
+                  const region_t *reg_visible attr_unused, GLuint source_texture,
+                  geometry_t source_size, GLuint target_fbo, GLuint default_mask,
+                  bool high_precision) {
 	bool ret = false;
 
 	if (source_size.width != bctx->fb_width || source_size.height != bctx->fb_height) {
@@ -400,12 +401,12 @@ bool gl_blur_impl(double opacity, struct gl_blur_context *bctx, void *mask, coor
 	return ret;
 }
 
-bool gl_blur(backend_t *base, double opacity, void *ctx, void *mask, coord_t mask_dst,
+bool gl_blur(backend_t *base, double opacity, void *ctx, image_handle mask, coord_t mask_dst,
              const region_t *reg_blur, const region_t *reg_visible attr_unused) {
 	auto gd = (struct gl_data *)base;
 	auto bctx = (struct gl_blur_context *)ctx;
-	return gl_blur_impl(opacity, bctx, mask, mask_dst, reg_blur, reg_visible,
-	                    gd->back_texture,
+	return gl_blur_impl(opacity, bctx, (struct backend_image *)mask, mask_dst,
+	                    reg_blur, reg_visible, gd->back_texture,
 	                    (geometry_t){.width = gd->width, .height = gd->height},
 	                    gd->back_fbo, gd->default_mask_texture, gd->dithered_present);
 }

--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -249,7 +249,7 @@ end:
 	return &gd->gl.base;
 }
 
-static void *
+static image_handle
 egl_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, bool owned) {
 	struct egl_data *gd = (void *)base;
 	struct egl_pixmap *eglpixmap = NULL;
@@ -301,7 +301,7 @@ egl_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, b
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	gl_check_err();
-	return wd;
+	return (image_handle)wd;
 err:
 	if (eglpixmap && eglpixmap->image) {
 		eglDestroyImage(gd->display, eglpixmap->image);

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "backend/backend.h"
+#include "backend/backend_common.h"
 #include "log.h"
 #include "region.h"
 
@@ -143,13 +144,13 @@ void *gl_create_window_shader(backend_t *backend_data, const char *source);
 void gl_destroy_window_shader(backend_t *backend_data, void *shader);
 uint64_t gl_get_shader_attributes(backend_t *backend_data, void *shader);
 bool gl_set_image_property(backend_t *backend_data, enum image_properties prop,
-                           void *image_data, void *args);
+                           image_handle image, void *args);
 bool gl_last_render_time(backend_t *backend_data, struct timespec *time);
 
 /**
  * @brief Render a region with texture data.
  */
-void gl_compose(backend_t *, void *image_data, coord_t image_dst, void *mask,
+void gl_compose(backend_t *, image_handle image, coord_t image_dst, image_handle mask,
                 coord_t mask_dst, const region_t *reg_tgt, const region_t *reg_visible);
 
 void gl_resize(struct gl_data *, int width, int height);
@@ -159,32 +160,32 @@ void gl_deinit(struct gl_data *gd);
 
 GLuint gl_new_texture(GLenum target);
 
-bool gl_image_op(backend_t *base, enum image_operations op, void *image_data,
+bool gl_image_op(backend_t *base, enum image_operations op, image_handle image,
                  const region_t *reg_op, const region_t *reg_visible, void *arg);
 
-void gl_release_image(backend_t *base, void *image_data);
-void *gl_make_mask(backend_t *base, geometry_t size, const region_t *reg);
+void gl_release_image(backend_t *base, image_handle image);
+image_handle gl_make_mask(backend_t *base, geometry_t size, const region_t *reg);
 
-void *gl_clone(backend_t *base, const void *image_data, const region_t *reg_visible);
+image_handle gl_clone(backend_t *base, image_handle image, const region_t *reg_visible);
 
-bool gl_blur(backend_t *base, double opacity, void *ctx, void *mask, coord_t mask_dst,
-             const region_t *reg_blur, const region_t *reg_visible);
-bool gl_blur_impl(double opacity, struct gl_blur_context *bctx, void *mask, coord_t mask_dst,
-                  const region_t *reg_blur, const region_t *reg_visible attr_unused,
-                  GLuint source_texture, geometry_t source_size, GLuint target_fbo,
-                  GLuint default_mask, bool high_precision);
+bool gl_blur(backend_t *base, double opacity, void *ctx, image_handle mask,
+             coord_t mask_dst, const region_t *reg_blur, const region_t *reg_visible);
+bool gl_blur_impl(double opacity, struct gl_blur_context *bctx,
+                  struct backend_image *mask, coord_t mask_dst, const region_t *reg_blur,
+                  const region_t *reg_visible attr_unused, GLuint source_texture,
+                  geometry_t source_size, GLuint target_fbo, GLuint default_mask,
+                  bool high_precision);
 void *gl_create_blur_context(backend_t *base, enum blur_method, void *args);
 void gl_destroy_blur_context(backend_t *base, void *ctx);
 struct backend_shadow_context *gl_create_shadow_context(backend_t *base, double radius);
 void gl_destroy_shadow_context(backend_t *base attr_unused, struct backend_shadow_context *ctx);
-void *gl_shadow_from_mask(backend_t *base, void *mask,
-                          struct backend_shadow_context *sctx, struct color color);
+image_handle gl_shadow_from_mask(backend_t *base, image_handle mask,
+                                 struct backend_shadow_context *sctx, struct color color);
 void gl_get_blur_size(void *blur_context, int *width, int *height);
 
 void gl_fill(backend_t *base, struct color, const region_t *clip);
 
 void gl_present(backend_t *base, const region_t *);
-bool gl_read_pixel(backend_t *base, void *image_data, int x, int y, struct color *output);
 enum device_status gl_device_status(backend_t *base);
 
 /**

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -380,7 +380,7 @@ end:
 	return &gd->gl.base;
 }
 
-static void *
+static image_handle
 glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, bool owned) {
 	struct _glx_pixmap *glxpixmap = NULL;
 	auto gd = (struct _glx_data *)base;
@@ -475,7 +475,7 @@ glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, b
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	gl_check_err();
-	return wd;
+	return (image_handle)wd;
 err:
 	if (glxpixmap && glxpixmap->glpixmap) {
 		glXDestroyPixmap(base->c->dpy, glxpixmap->glpixmap);

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -359,10 +359,12 @@ compose_impl(struct _xrender_data *xd, struct xrender_image *xrimg, coord_t dst,
 	pixman_region32_fini(&reg);
 }
 
-static void compose(backend_t *base, void *img_data, coord_t dst, void *mask, coord_t mask_dst,
-                    const region_t *reg_paint, const region_t *reg_visible) {
+static void compose(backend_t *base, image_handle image_, coord_t dst, image_handle mask_,
+                    coord_t mask_dst, const region_t *reg_paint, const region_t *reg_visible) {
 	struct _xrender_data *xd = (void *)base;
-	return compose_impl(xd, img_data, dst, mask, mask_dst, reg_paint, reg_visible,
+	auto image = (struct xrender_image *)image_;
+	auto mask = (struct xrender_image *)mask_;
+	return compose_impl(xd, image, dst, mask, mask_dst, reg_paint, reg_visible,
 	                    xd->back[2]);
 }
 
@@ -384,9 +386,10 @@ static void fill(backend_t *base, struct color c, const region_t *clip) {
 	                         .height = to_u16_checked(extent->y2 - extent->y1)}});
 }
 
-static bool blur(backend_t *backend_data, double opacity, void *ctx_, void *mask,
+static bool blur(backend_t *backend_data, double opacity, void *ctx_, image_handle mask_,
                  coord_t mask_dst, const region_t *reg_blur, const region_t *reg_visible) {
-	struct _xrender_blur_context *bctx = ctx_;
+	auto bctx = (struct _xrender_blur_context *)ctx_;
+	auto mask = (struct xrender_image *)mask_;
 	if (bctx->method == BLUR_METHOD_NONE) {
 		return true;
 	}
@@ -517,7 +520,7 @@ static bool blur(backend_t *backend_data, double opacity, void *ctx_, void *mask
 	return true;
 }
 
-static void *
+static image_handle
 bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, bool owned) {
 	xcb_generic_error_t *e;
 	auto r = xcb_get_geometry_reply(base->c->c, xcb_get_geometry(base->c->c, pixmap), &e);
@@ -552,7 +555,7 @@ bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, bool 
 		free(img);
 		return NULL;
 	}
-	return img;
+	return (image_handle)img;
 }
 static void release_image_inner(backend_t *base, struct _xrender_image_data_inner *inner) {
 	x_free_picture(base->c, inner->pict);
@@ -576,13 +579,13 @@ release_rounded_corner_cache(backend_t *base, struct xrender_rounded_rectangle_c
 	}
 }
 
-static void release_image(backend_t *base, void *image) {
-	struct xrender_image *img = image;
+static void release_image(backend_t *base, image_handle image) {
+	auto img = (struct xrender_image *)image;
 	release_rounded_corner_cache(base, img->rounded_rectangle);
 	img->rounded_rectangle = NULL;
 	img->base.inner->refcount -= 1;
 	if (img->base.inner->refcount == 0) {
-		release_image_inner(base, (void *)img->base.inner);
+		release_image_inner(base, (struct _xrender_image_data_inner *)img->base.inner);
 	}
 	free(img);
 }
@@ -711,7 +714,7 @@ new_inner(backend_t *base, int w, int h, xcb_visualid_t visual, uint8_t depth) {
 	return new_inner;
 }
 
-static void *make_mask(backend_t *base, geometry_t size, const region_t *reg) {
+static image_handle make_mask(backend_t *base, geometry_t size, const region_t *reg) {
 	struct _xrender_data *xd = (void *)base;
 	// Give the mask a 1 pixel wide border to emulate the clamp to border behavior of
 	// OpenGL textures.
@@ -754,7 +757,7 @@ static void *make_mask(backend_t *base, geometry_t size, const region_t *reg) {
 	img->base.dim = 0;
 	img->base.inner = (struct backend_image_inner_base *)inner;
 	img->rounded_rectangle = NULL;
-	return img;
+	return (image_handle)img;
 }
 
 static bool decouple_image(backend_t *base, struct backend_image *img, const region_t *reg) {
@@ -782,10 +785,10 @@ static bool decouple_image(backend_t *base, struct backend_image *img, const reg
 	return true;
 }
 
-static bool image_op(backend_t *base, enum image_operations op, void *image,
+static bool image_op(backend_t *base, enum image_operations op, image_handle image,
                      const region_t *reg_op, const region_t *reg_visible, void *arg) {
 	struct _xrender_data *xd = (void *)base;
-	struct backend_image *img = image;
+	auto img = (struct backend_image *)image;
 	region_t reg;
 	double *dargs = arg;
 
@@ -964,19 +967,19 @@ err:
 	return NULL;
 }
 
-void *clone_image(backend_t *base attr_unused, const void *image_data,
-                  const region_t *reg_visible attr_unused) {
+image_handle clone_image(backend_t *base attr_unused, image_handle image,
+                         const region_t *reg_visible attr_unused) {
 	auto new_img = ccalloc(1, struct xrender_image);
-	*new_img = *(struct xrender_image *)image_data;
+	*new_img = *(struct xrender_image *)image;
 	new_img->base.inner->refcount++;
 	if (new_img->rounded_rectangle) {
 		new_img->rounded_rectangle->refcount++;
 	}
-	return new_img;
+	return (image_handle)new_img;
 }
 
-static bool
-set_image_property(backend_t *base, enum image_properties op, void *image, void *args) {
+static bool set_image_property(backend_t *base, enum image_properties op,
+                               image_handle image, void *args) {
 	auto xrimg = (struct xrender_image *)image;
 	if (op == IMAGE_PROPERTY_CORNER_RADIUS &&
 	    ((double *)args)[0] != xrimg->base.corner_radius) {

--- a/src/common.h
+++ b/src/common.h
@@ -186,7 +186,7 @@ typedef struct session {
 	/// Picture of the root window background.
 	paint_t root_tile_paint;
 	/// The backend data the root pixmap bound to
-	void *root_image;
+	image_handle root_image;
 	/// A region of the size of the screen.
 	region_t screen_reg;
 	/// Picture of root window. Destination of painting in no-DBE painting

--- a/src/win.h
+++ b/src/win.h
@@ -100,9 +100,9 @@ struct managed_win {
 	struct win base;
 	/// backend data attached to this window. Only available when
 	/// `state` is not UNMAPPED
-	void *win_image;
-	void *shadow_image;
-	void *mask_image;
+	image_handle win_image;
+	image_handle shadow_image;
+	image_handle mask_image;
 	/// Pointer to the next higher window to paint.
 	struct managed_win *prev_trans;
 	/// Number of windows above this window


### PR DESCRIPTION
It's quite confusing what should be passed into what because too many things are `void *`. So give images a type to make things a bit clearer. Because of C's limited type system, we lose the ability to annotate them as nonnull or const, well you win some you lose some.

Also while doing this I noticed error handling around this is a bit lacking.

