### PR TITLE
use more xcb-util functions

### DIFF
--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <xcb/composite.h>
 #include <xcb/xcb.h>
+#include <xcb/xcb_aux.h>
 
 #include "backend/backend.h"
 #include "backend/backend_common.h"
@@ -114,7 +115,8 @@ struct glx_fbconfig_info *glx_find_fbconfig(struct x_connection *c, struct xvisu
 		int visual;
 		glXGetFBConfigAttribChecked(c->dpy, cfg[i], GLX_VISUAL_ID, &visual);
 		if (m.visual_depth != -1 &&
-		    x_get_visual_depth(c, (xcb_visualid_t)visual) != m.visual_depth) {
+		    xcb_aux_get_depth_of_visual(c->screen_info, (xcb_visualid_t)visual) !=
+		        m.visual_depth) {
 			// FBConfig and the correspondent X Visual might not have the same
 			// depth. (e.g. 32 bit FBConfig with a 24 bit Visual). This is
 			// quite common, seen in both open source and proprietary drivers.

--- a/src/picom.c
+++ b/src/picom.c
@@ -1188,7 +1188,7 @@ void root_damaged(session_t *ps) {
 			xcb_visualid_t visual =
 			    r->depth == ps->c.screen_info->root_depth
 			        ? ps->c.screen_info->root_visual
-			        : x_get_visual_for_depth(&ps->c, r->depth);
+			        : x_get_visual_for_depth(ps->c.screen_info, r->depth);
 			free(r);
 
 			ps->root_image = ps->backend_data->ops->bind_pixmap(

--- a/src/picom.c
+++ b/src/picom.c
@@ -35,6 +35,7 @@
 #include <xcb/randr.h>
 #include <xcb/render.h>
 #include <xcb/sync.h>
+#include <xcb/xcb_aux.h>
 #include <xcb/xfixes.h>
 
 #include <ev.h>
@@ -1501,7 +1502,7 @@ static bool redirect_start(session_t *ps) {
 		return false;
 	}
 
-	x_sync(&ps->c);
+	xcb_aux_sync(ps->c.c);
 
 	if (!initialize_backend(ps)) {
 		return false;
@@ -1560,7 +1561,7 @@ static bool redirect_start(session_t *ps) {
 	}
 
 	// Must call XSync() here
-	x_sync(&ps->c);
+	xcb_aux_sync(ps->c.c);
 
 	ps->redirected = true;
 	ps->first_frame = true;
@@ -1603,7 +1604,7 @@ static void unredirect(session_t *ps) {
 	}
 
 	// Must call XSync() here
-	x_sync(&ps->c);
+	xcb_aux_sync(ps->c.c);
 
 	ps->redirected = false;
 	log_debug("Screen unredirected.");
@@ -2789,7 +2790,7 @@ static void session_destroy(session_t *ps) {
 #endif
 
 	// Flush all events
-	x_sync(&ps->c);
+	xcb_aux_sync(ps->c.c);
 	ev_io_stop(ps->loop, &ps->xiow);
 	if (ps->o.legacy_backends) {
 		free_conv((conv *)ps->shadow_context);

--- a/src/render.c
+++ b/src/render.c
@@ -624,7 +624,7 @@ static bool get_root_tile(session_t *ps) {
 	} else {
 		visual = r->depth == ps->c.screen_info->root_depth
 		             ? ps->c.screen_info->root_visual
-		             : x_get_visual_for_depth(&ps->c, r->depth);
+		             : x_get_visual_for_depth(ps->c.screen_info, r->depth);
 		free(r);
 	}
 

--- a/src/render.c
+++ b/src/render.c
@@ -6,6 +6,7 @@
 #include <xcb/composite.h>
 #include <xcb/render.h>
 #include <xcb/sync.h>
+#include <xcb/xcb_aux.h>
 #include <xcb/xcb_image.h>
 #include <xcb/xcb_renderutil.h>
 
@@ -1229,7 +1230,7 @@ void paint_all(session_t *ps, struct managed_win *t) {
 	if (ps->o.vsync) {
 		// Make sure all previous requests are processed to achieve best
 		// effect
-		x_sync(&ps->c);
+		xcb_aux_sync(ps->c.c);
 #ifdef CONFIG_OPENGL
 		if (glx_has_context(ps)) {
 			if (ps->o.vsync_use_glfinish) {
@@ -1288,7 +1289,7 @@ void paint_all(session_t *ps, struct managed_win *t) {
 		break;
 #ifdef CONFIG_OPENGL
 	case BKEND_XR_GLX_HYBRID:
-		x_sync(&ps->c);
+		xcb_aux_sync(ps->c.c);
 		if (ps->o.vsync_use_glfinish) {
 			glFinish();
 		} else {
@@ -1313,7 +1314,7 @@ void paint_all(session_t *ps, struct managed_win *t) {
 	default: assert(0);
 	}
 
-	x_sync(&ps->c);
+	xcb_aux_sync(ps->c.c);
 
 #ifdef CONFIG_OPENGL
 	if (glx_has_context(ps)) {

--- a/src/x.c
+++ b/src/x.c
@@ -346,24 +346,6 @@ x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std) {
 	return pictfmt->id;
 }
 
-int x_get_visual_depth(struct x_connection *c, xcb_visualid_t visual) {
-	auto setup = xcb_get_setup(c->c);
-	for (auto screen = xcb_setup_roots_iterator(setup); screen.rem;
-	     xcb_screen_next(&screen)) {
-		for (auto depth = xcb_screen_allowed_depths_iterator(screen.data);
-		     depth.rem; xcb_depth_next(&depth)) {
-			const int len = xcb_depth_visuals_length(depth.data);
-			const xcb_visualtype_t *visuals = xcb_depth_visuals(depth.data);
-			for (int i = 0; i < len; i++) {
-				if (visual == visuals[i].visual_id) {
-					return depth.data->depth;
-				}
-			}
-		}
-	}
-	return -1;
-}
-
 xcb_render_picture_t
 x_create_picture_with_pictfmt_and_pixmap(struct x_connection *c,
                                          const xcb_render_pictforminfo_t *pictfmt,
@@ -606,9 +588,7 @@ _x_strerror(unsigned long serial, uint8_t major, uint16_t minor, uint8_t error_c
 	const char *name = "Unknown";
 
 #define CASESTRRET(s)                                                                    \
-	case s:                                                                          \
-		name = #s;                                                               \
-		break
+	case s: name = #s; break
 
 #define CASESTRRET2(s)                                                                   \
 	case XCB_##s: name = #s; break
@@ -879,8 +859,8 @@ void x_create_convolution_kernel(const conv *kernel, double center,
 /// Returns {-1, -1, -1, -1, -1, 0} on failure
 struct xvisual_info x_get_visual_info(struct x_connection *c, xcb_visualid_t visual) {
 	auto pictfmt = x_get_pictform_for_visual(c, visual);
-	auto depth = x_get_visual_depth(c, visual);
-	if (!pictfmt || depth == -1) {
+	auto depth = xcb_aux_get_depth_of_visual(c->screen_info, visual);
+	if (!pictfmt || depth == 0) {
 		log_error("Invalid visual %#03x", visual);
 		return (struct xvisual_info){-1, -1, -1, -1, -1, 0};
 	}

--- a/src/x.c
+++ b/src/x.c
@@ -16,6 +16,7 @@
 #include <xcb/render.h>
 #include <xcb/sync.h>
 #include <xcb/xcb.h>
+#include <xcb/xcb_aux.h>
 #include <xcb/xcb_renderutil.h>
 #include <xcb/xfixes.h>
 
@@ -94,7 +95,7 @@ void x_connection_init(struct x_connection *c, Display *dpy) {
 	c->previous_xerror_handler = XSetErrorHandler(xerror);
 
 	c->screen = DefaultScreen(dpy);
-	c->screen_info = x_screen_of_display(c, c->screen);
+	c->screen_info = xcb_aux_get_screen(c->c, c->screen);
 }
 
 /**
@@ -902,19 +903,6 @@ struct xvisual_info x_get_visual_info(struct x_connection *c, xcb_visualid_t vis
 	    .visual_depth = depth,
 	    .visual = visual,
 	};
-}
-
-xcb_screen_t *x_screen_of_display(struct x_connection *c, int screen) {
-	xcb_screen_iterator_t iter;
-
-	iter = xcb_setup_roots_iterator(xcb_get_setup(c->c));
-	for (; iter.rem; --screen, xcb_screen_next(&iter)) {
-		if (screen == 0) {
-			return iter.data;
-		}
-	}
-
-	return NULL;
 }
 
 void x_update_monitors(struct x_connection *c, struct x_monitors *m) {

--- a/src/x.c
+++ b/src/x.c
@@ -322,15 +322,11 @@ xcb_visualid_t x_get_visual_for_standard(struct x_connection *c, xcb_pict_standa
 	return x_get_visual_for_pictfmt(g_pictfmts, pictfmt->id);
 }
 
-xcb_visualid_t x_get_visual_for_depth(struct x_connection *c, uint8_t depth) {
-	xcb_screen_iterator_t screen_it = xcb_setup_roots_iterator(xcb_get_setup(c->c));
-	for (; screen_it.rem; xcb_screen_next(&screen_it)) {
-		xcb_depth_iterator_t depth_it =
-		    xcb_screen_allowed_depths_iterator(screen_it.data);
-		for (; depth_it.rem; xcb_depth_next(&depth_it)) {
-			if (depth_it.data->depth == depth) {
-				return xcb_depth_visuals_iterator(depth_it.data).data->visual_id;
-			}
+xcb_visualid_t x_get_visual_for_depth(xcb_screen_t *screen, uint8_t depth) {
+	xcb_depth_iterator_t depth_it = xcb_screen_allowed_depths_iterator(screen);
+	for (; depth_it.rem; xcb_depth_next(&depth_it)) {
+		if (depth_it.data->depth == depth) {
+			return xcb_depth_visuals_iterator(depth_it.data).data->visual_id;
 		}
 	}
 

--- a/src/x.h
+++ b/src/x.h
@@ -265,7 +265,6 @@ bool wid_get_text_prop(session_t *ps, xcb_window_t wid, xcb_atom_t prop, char **
 
 const xcb_render_pictforminfo_t *
 x_get_pictform_for_visual(struct x_connection *, xcb_visualid_t);
-int x_get_visual_depth(struct x_connection *, xcb_visualid_t);
 
 xcb_render_picture_t
 x_create_picture_with_pictfmt_and_pixmap(struct x_connection *,

--- a/src/x.h
+++ b/src/x.h
@@ -208,17 +208,6 @@ void x_discard_pending(struct x_connection *c, uint32_t sequence);
 void x_handle_error(struct x_connection *c, xcb_generic_error_t *ev);
 
 /**
- * Send a request to X server and get the reply to make sure all previous
- * requests are processed, and their replies received
- *
- * xcb_get_input_focus is used here because it is the same request used by
- * libX11
- */
-static inline void x_sync(struct x_connection *c) {
-	free(xcb_get_input_focus_reply(c->c, xcb_get_input_focus(c->c), NULL));
-}
-
-/**
  * Get a specific attribute of a window.
  *
  * Returns a blank structure if the returned type and format does not

--- a/src/x.h
+++ b/src/x.h
@@ -397,7 +397,7 @@ struct xvisual_info x_get_visual_info(struct x_connection *c, xcb_visualid_t vis
 
 xcb_visualid_t x_get_visual_for_standard(struct x_connection *c, xcb_pict_standard_t std);
 
-xcb_visualid_t x_get_visual_for_depth(struct x_connection *c, uint8_t depth);
+xcb_visualid_t x_get_visual_for_depth(xcb_screen_t *screen, uint8_t depth);
 
 xcb_render_pictformat_t
 x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std);

--- a/src/x.h
+++ b/src/x.h
@@ -414,8 +414,6 @@ xcb_visualid_t x_get_visual_for_depth(struct x_connection *c, uint8_t depth);
 xcb_render_pictformat_t
 x_get_pictfmt_for_standard(struct x_connection *c, xcb_pict_standard_t std);
 
-xcb_screen_t *x_screen_of_display(struct x_connection *c, int screen);
-
 /// Populates a `struct x_monitors` with the current monitor configuration.
 void x_update_monitors(struct x_connection *, struct x_monitors *);
 /// Free memory allocated for a `struct x_monitors`.


### PR DESCRIPTION
there are possibly other useful functions but these are the obvious ones.

### x: remove x_screen_of_display and use xcb_aux_get_screen instead

### x: remove x_sync and use xcb_aux_sync instead

### x: remove x_get_visual_depth and use xcb_aux_get_depth_of_visual instead

### x: don't require an entire struct x_connection in x_get_visual_for_depth
inspired by the xcb-util's xcb_aux_get_depth_of_visual function
implementation