### PR TITLE
win: store focused state in struct managed_win

### DIFF
--- a/src/c2.c
+++ b/src/c2.c
@@ -1383,9 +1383,7 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 			case C2_L_PFULLSCREEN: predef_target = w->is_fullscreen; break;
 			case C2_L_POVREDIR: predef_target = w->a.override_redirect; break;
 			case C2_L_PARGB: predef_target = win_has_alpha(w); break;
-			case C2_L_PFOCUSED:
-				predef_target = win_is_focused_raw(ps, w);
-				break;
+			case C2_L_PFOCUSED: predef_target = win_is_focused_raw(w); break;
 			case C2_L_PWMWIN: predef_target = w->wmwin; break;
 			case C2_L_PBSHAPED: predef_target = w->bounding_shaped; break;
 			case C2_L_PROUNDED: predef_target = w->rounded_corners; break;

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -906,7 +906,7 @@ cdbus_process_window_property_get(session_t *ps, DBusMessage *msg, cdbus_window_
 	}
 	if (!strcmp("RawFocused", target)) {
 		cdbus_reply(ps, msg, cdbus_append_bool_variant,
-		            (bool[]){win_is_focused_raw(ps, w)});
+		            (bool[]){win_is_focused_raw(w)});
 		return true;
 	}
 
@@ -976,7 +976,7 @@ static bool cdbus_process_win_get(session_t *ps, DBusMessage *msg) {
 	cdbus_m_win_get_do(wmwin, cdbus_reply_bool);
 	cdbus_m_win_get_do(leader, cdbus_reply_wid);
 	if (!strcmp("focused_raw", target)) {
-		cdbus_reply_bool(ps, msg, win_is_focused_raw(ps, w));
+		cdbus_reply_bool(ps, msg, win_is_focused_raw(w));
 		return true;
 	}
 	cdbus_m_win_get_do(fade_force, cdbus_reply_enum);

--- a/src/win.h
+++ b/src/win.h
@@ -205,6 +205,8 @@ struct managed_win {
 	/// `is_ewmh_fullscreen`, or the windows spatial relation with the
 	/// root window. Which one is used is determined by user configuration.
 	bool is_fullscreen;
+	/// Whether the window is the EWMH active window.
+	bool is_ewmh_focused;
 
 	// Opacity-related members
 	/// Current window opacity.
@@ -435,7 +437,7 @@ struct managed_win *find_managed_window_or_parent(session_t *ps, xcb_window_t wi
 /**
  * Check if a window is focused, without using any focus rules or forced focus settings
  */
-bool attr_pure win_is_focused_raw(const session_t *ps, const struct managed_win *w);
+bool attr_pure win_is_focused_raw(const struct managed_win *w);
 
 /// check if window has ARGB visual
 bool attr_pure win_has_alpha(const struct managed_win *w);


### PR DESCRIPTION
So we don't need the whole session_t just to check if a window is focused.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
