### PR TITLE
fix: add libepoxy to default nix overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,39 +7,55 @@
     };
   };
   outputs = {
-    self, flake-utils, nixpkgs, git-ignore-nix, ...
-  }: flake-utils.lib.eachDefaultSystem (system: let
-    overlay = self: super: {
-      picom = super.picom.overrideAttrs (oldAttrs: rec {
-        pname = "picom";
-        buildInputs = [
-          self.pcre2 self.xorg.xcbutil self.libepoxy
-        ] ++ self.lib.remove self.xorg.libXinerama (
-          self.lib.remove self.pcre oldAttrs.buildInputs
-        );
-        src = git-ignore-nix.lib.gitignoreSource ./.;
-      });
-    };
-    pkgs = import nixpkgs { inherit system overlays; config.allowBroken = true; };
-    overlays = [ overlay ];
-  in rec {
-    inherit overlay overlays;
-    defaultPackage = pkgs.picom.overrideAttrs (o: {
-      version = "11";
-      src = ./.;
-      buildInputs = o.buildInputs ++ [ pkgs.libepoxy ];
+    self,
+    flake-utils,
+    nixpkgs,
+    git-ignore-nix,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      overlay = self: super: {
+        picom = super.picom.overrideAttrs (oldAttrs: rec {
+          version = "11";
+          pname = "picom";
+          buildInputs =
+            [
+              self.pcre2
+              self.xorg.xcbutil
+              self.libepoxy
+            ]
+            ++ self.lib.remove self.xorg.libXinerama (
+              self.lib.remove self.pcre oldAttrs.buildInputs
+            );
+          src = git-ignore-nix.lib.gitignoreSource ./.;
+        });
+      };
+
+      pkgs = import nixpkgs {
+        inherit system overlays;
+        config.allowBroken = true;
+      };
+
+      overlays = [overlay];
+    in rec {
+      inherit
+        overlay
+        overlays
+        ;
+      defaultPackage = pkgs.picom;
+      devShell = defaultPackage.overrideAttrs {
+        buildInputs =
+          defaultPackage.buildInputs
+          ++ (with pkgs; [
+            clang-tools_17
+            llvmPackages_17.clang-unwrapped.python
+          ]);
+        hardeningDisable = ["fortify"];
+        shellHook = ''
+          # Workaround a NixOS limitation on sanitizers:
+          # See: https://github.com/NixOS/nixpkgs/issues/287763
+          export LD_LIBRARY_PATH+=":/run/opengl-driver/lib"
+        '';
+      };
     });
-    devShell = defaultPackage.overrideAttrs {
-      buildInputs = defaultPackage.buildInputs ++ (with pkgs; [
-        clang-tools_17
-        llvmPackages_17.clang-unwrapped.python
-      ]);
-      hardeningDisable = [ "fortify" ];
-      shellHook = ''
-        # Workaround a NixOS limitation on sanitizers:
-        # See: https://github.com/NixOS/nixpkgs/issues/287763
-        export LD_LIBRARY_PATH+=":/run/opengl-driver/lib"
-      '';
-    };
-  });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       picom = super.picom.overrideAttrs (oldAttrs: rec {
         pname = "picom";
         buildInputs = [
-          self.pcre2 self.xorg.xcbutil
+          self.pcre2 self.xorg.xcbutil self.libepoxy
         ] ++ self.lib.remove self.xorg.libXinerama (
           self.lib.remove self.pcre oldAttrs.buildInputs
         );


### PR DESCRIPTION
<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->

It seems like when updating flake.nix libepoxy was added to defaultPackage, but wasn't for the default overlay, which may break systems that use overlays. This pr fixes that problem.