### PR TITLE
win: remove the SHADOW_* window flags

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -334,7 +334,14 @@ bool paint_all_new(session_t *ps, struct managed_win *const t) {
 
 		// Draw shadow on target
 		if (w->shadow) {
-			assert(!(w->flags & WIN_FLAGS_SHADOW_NONE));
+			if (w->shadow_image == NULL) {
+				struct color shadow_color = {.red = ps->o.shadow_red,
+				                             .green = ps->o.shadow_green,
+				                             .blue = ps->o.shadow_blue,
+				                             .alpha = ps->o.shadow_opacity};
+				win_bind_shadow(ps->backend_data, w, shadow_color,
+				                ps->shadow_context);
+			}
 			// Clip region for the shadow
 			// reg_shadow \in reg_paint
 			auto reg_shadow = win_extents_by_val(w);

--- a/src/picom.c
+++ b/src/picom.c
@@ -628,7 +628,7 @@ static void destroy_backend(session_t *ps) {
 			// Unmapped windows could still have shadow images, but not pixmap
 			// images
 			assert(!w->win_image || w->state != WSTATE_UNMAPPED);
-			if (win_check_flags_any(w, WIN_FLAGS_IMAGES_STALE) &&
+			if (win_check_flags_any(w, WIN_FLAGS_PIXMAP_STALE) &&
 			    w->state == WSTATE_MAPPED) {
 				log_warn("Stale flags set for mapped window %#010x "
 				         "during backend destruction",
@@ -637,7 +637,7 @@ static void destroy_backend(session_t *ps) {
 			}
 			// Unmapped windows can still have stale flags set, because their
 			// stale flags aren't handled until they are mapped.
-			win_clear_flags(w, WIN_FLAGS_IMAGES_STALE);
+			win_clear_flags(w, WIN_FLAGS_PIXMAP_STALE);
 			win_release_images(ps->backend_data, w);
 		}
 		free_paint(ps, &w->paint);
@@ -769,7 +769,7 @@ static bool initialize_backend(session_t *ps) {
 			log_debug("Marking window %#010x (%s) for update after "
 			          "redirection",
 			          w->base.id, w->name);
-			win_set_flags(w, WIN_FLAGS_IMAGES_STALE);
+			win_set_flags(w, WIN_FLAGS_PIXMAP_STALE);
 			ps->pending_updates = true;
 		}
 	}

--- a/src/win_defs.h
+++ b/src/win_defs.h
@@ -77,10 +77,6 @@ enum win_flags {
 	WIN_FLAGS_PIXMAP_NONE = 2,
 	/// there was an error trying to bind the images
 	WIN_FLAGS_IMAGE_ERROR = 4,
-	/// shadow is out of date, will be updated in win_process_flags
-	WIN_FLAGS_SHADOW_STALE = 8,
-	/// shadow has not been generated
-	WIN_FLAGS_SHADOW_NONE = 16,
 	/// the client window needs to be updated
 	WIN_FLAGS_CLIENT_STALE = 32,
 	/// the window is mapped by X, we need to call map_win_start for it
@@ -95,8 +91,3 @@ enum win_flags {
 	/// need better name for this, is set when some aspects of the window changed
 	WIN_FLAGS_FACTOR_CHANGED = 1024,
 };
-
-static const uint64_t WIN_FLAGS_IMAGES_STALE =
-    WIN_FLAGS_PIXMAP_STALE | WIN_FLAGS_SHADOW_STALE;
-
-#define WIN_FLAGS_IMAGES_NONE (WIN_FLAGS_PIXMAP_NONE | WIN_FLAGS_SHADOW_NONE)


### PR DESCRIPTION
The window flags are used for delaying updates until we have grabbed the X server. This is to make sure our internal states are in sync with the server's state, to avoid race conditions.

Since shadow state is purely internal to picom, there is no need for delaying its update, and thus these flags can be removed.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
