### PR TITLE
c2: remove type specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Notable changes
 
 * Marginally improve performance when resizing/opening/closing windows. (#1190)
-* Format specifiers are no longer used in rules. Format specifier is the number you put after the colon (':') in rules, e.g. the `32` in `"_GTK_FRAME_EXTENTS@:32c"`. Now this information is ignored and the property is matched regardless of format.
+* Type and format specifiers are no longer used in rules. These specifiers are what you put after the colon (':') in rules, e.g. the `:32c` in `"_GTK_FRAME_EXTENTS@:32c"`. Now this information is ignored and the property is matched regardless of format or type.
 
 ## Dependency changes
 

--- a/man/picom.1.asciidoc
+++ b/man/picom.1.asciidoc
@@ -286,15 +286,15 @@ Some options accept a condition string to match certain windows. A condition str
 
 A condition with "exists" operator looks like this:
 
-	<NEGATION> <TARGET> <CLIENT/FRAME> [<INDEX>] : <TYPE>
+	<NEGATION> <TARGET> <CLIENT/FRAME> [<INDEX>]
 
 With equals operator it looks like:
 
-	<NEGATION> <TARGET> <CLIENT/FRAME> [<INDEX>] : <TYPE> <NEGATION> <OP QUALIFIER> <MATCH TYPE> = <PATTERN>
+	<NEGATION> <TARGET> <CLIENT/FRAME> [<INDEX>] <NEGATION> <OP QUALIFIER> <MATCH TYPE> = <PATTERN>
 
 With greater-than/less-than operators it looks like:
 
-	<NEGATION> <TARGET> <CLIENT/FRAME> [<INDEX>] : <TYPE> <NEGATION> <OPERATOR> <PATTERN>
+	<NEGATION> <TARGET> <CLIENT/FRAME> [<INDEX>] <NEGATION> <OPERATOR> <PATTERN>
 
 'NEGATION' (optional) is one or more exclamation marks;
 
@@ -303,8 +303,6 @@ With greater-than/less-than operators it looks like:
 'CLIENT/FRAME' is a single `@` if the window attribute should be be looked up on client window, nothing if on frame window;
 
 'INDEX' (optional) is the index number of the property to look up. For example, `[2]` means look at the third value in the property. If not specified, the first value (index `[0]`) is used implicitly. Use the special value `[*]` to perform matching against all available property values using logical OR. Do not specify it for predefined targets.
-
-'TYPE' is a single character representing the type of the property to match for: `c` for 'CARDINAL', `a` for 'ATOM', `w` for 'WINDOW', `d` for 'DRAWABLE', `s` for 'STRING' (and any other string types, such as 'UTF8_STRING'). Do not specify it for predefined targets.
 
 'OP QUALIFIER' (optional), applicable only for equals operator, could be `?` (ignore-case).
 
@@ -328,24 +326,24 @@ Examples:
 	override_redirect != 1
 	# If the window is a menu
 	window_type *= "menu"
-	_NET_WM_WINDOW_TYPE@:a *= "MENU"
+	_NET_WM_WINDOW_TYPE@ *= "MENU"
 	# If the window is marked hidden: _NET_WM_STATE contains _NET_WM_STATE_HIDDEN
-	_NET_WM_STATE@[*]:a = "_NET_WM_STATE_HIDDEN"
+	_NET_WM_STATE@[*] = "_NET_WM_STATE_HIDDEN"
 	# If the window is marked sticky: _NET_WM_STATE contains an atom that contains
 	# "sticky", ignore case
-	_NET_WM_STATE@[*]:a *?= "sticky"
+	_NET_WM_STATE@[*] *?= "sticky"
 	# If the window name contains "Firefox", ignore case
 	name *?= "Firefox"
-	_NET_WM_NAME@:s *?= "Firefox"
+	_NET_WM_NAME@ *?= "Firefox"
 	# If the window name ends with "Firefox"
 	name %= "*Firefox"
 	name ~= "Firefox$"
 	# If the window has a property _COMPTON_SHADOW with value 0, type CARDINAL,
 	# format 32, value 0, on its frame window
-	_COMPTON_SHADOW:32c = 0
+	_COMPTON_SHADOW = 0
 	# If the third value of _NET_FRAME_EXTENTS is less than 20, or there's no
 	# _NET_FRAME_EXTENTS property on client window
-	_NET_FRAME_EXTENTS@[2]:32c < 20 || !_NET_FRAME_EXTENTS@:32c
+	_NET_FRAME_EXTENTS@[2] < 20 || !_NET_FRAME_EXTENTS@
 	# The pattern here will be parsed as "dd4"
 	name = "\x64\x64\o64"
 

--- a/src/x.c
+++ b/src/x.c
@@ -193,7 +193,7 @@ bool wid_get_text_prop(struct x_connection *c, struct atom *atoms, xcb_window_t 
 		return false;
 	}
 
-	if (type != XCB_ATOM_STRING && type != atoms->aUTF8_STRING && type != atoms->aC_STRING) {
+	if (!x_is_type_string(atoms, type)) {
 		log_warn("Text property %d of window %#010x has unsupported type: %d",
 		         prop, wid, type);
 		return false;

--- a/src/x.h
+++ b/src/x.h
@@ -11,6 +11,7 @@
 #include <xcb/xcb_renderutil.h>
 #include <xcb/xfixes.h>
 
+#include "atom.h"
 #include "compiler.h"
 #include "kernel.h"
 #include "log.h"
@@ -263,6 +264,11 @@ xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid, xcb_a
  */
 bool wid_get_text_prop(struct x_connection *c, struct atom *atoms, xcb_window_t wid,
                        xcb_atom_t prop, char ***pstrlst, int *pnstr);
+
+static inline bool x_is_type_string(struct atom *atoms, xcb_atom_t type) {
+	return type == XCB_ATOM_STRING || type == atoms->aUTF8_STRING ||
+	       type == atoms->aC_STRING;
+}
 
 const xcb_render_pictforminfo_t *
 x_get_pictform_for_visual(struct x_connection *, xcb_visualid_t);


### PR DESCRIPTION
Same logic as the format specifiers, we just use what the X server reports, asking the user for the type is just going to be confusing.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
