### PR TITLE
core: disable realtime scheduling by default

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -152,6 +152,8 @@ typedef struct options {
 	bool no_x_selection;
 	/// Window type option override.
 	win_option_t wintype_option[NUM_WINTYPES];
+	/// Whether to set realtime scheduling policy for the compositor process.
+	bool use_realtime_scheduling;
 
 	// === VSync & software optimization ===
 	/// VSync method to use;

--- a/src/options.c
+++ b/src/options.c
@@ -185,6 +185,8 @@ static const struct picom_option picom_options[] = {
                                                                              "you want to attach a debugger to picom"},
     {"no-ewmh-fullscreen"          , no_argument      , 803, NULL          , "Do not use EWMH to detect fullscreen windows. Reverts to checking if a "
                                                                              "window is fullscreen based only on its size and coordinates."},
+    {"realtime"                    , no_argument      , 804, NULL          , "Enable realtime scheduling. This might reduce latency, but might also cause "
+                                                                             "other issues. Disable this if you see the compositor being killed."},
 };
 // clang-format on
 
@@ -750,6 +752,7 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 			break;
 		P_CASEBOOL(802, debug_mode);
 		P_CASEBOOL(803, no_ewmh_fullscreen);
+		P_CASEBOOL(804, use_realtime_scheduling);
 		default: usage(argv[0], 1); break;
 #undef P_CASEBOOL
 		}

--- a/src/picom.c
+++ b/src/picom.c
@@ -1569,8 +1569,9 @@ static bool redirect_start(session_t *ps) {
 			    (enum vblank_scheduler_type)ps->o.debug_options.force_vblank_scheduler;
 		}
 		log_info("Using vblank scheduler: %s.", vblank_scheduler_str[scheduler_type]);
-		ps->vblank_scheduler = vblank_scheduler_new(
-		    ps->loop, &ps->c, session_get_target_window(ps), scheduler_type);
+		ps->vblank_scheduler =
+		    vblank_scheduler_new(ps->loop, &ps->c, session_get_target_window(ps),
+		                         scheduler_type, ps->o.use_realtime_scheduling);
 		if (!ps->vblank_scheduler) {
 			return false;
 		}
@@ -2740,7 +2741,10 @@ static void session_destroy(session_t *ps) {
  * @param ps current session
  */
 static void session_run(session_t *ps) {
-	set_rr_scheduling();
+	if (ps->o.use_realtime_scheduling) {
+		set_rr_scheduling();
+	}
+
 	// In benchmark mode, we want draw_timer handler to always be active
 	if (ps->o.benchmark) {
 		ev_timer_set(&ps->draw_timer, 0, 0);

--- a/src/utils.c
+++ b/src/utils.c
@@ -282,6 +282,12 @@ void rolling_quantile_pop_front(struct rolling_quantile *rq, int x) {
 /// This requires the user to set up permissions for the real-time scheduling. e.g. by
 /// setting `ulimit -r`, or giving us the CAP_SYS_NICE capability.
 void set_rr_scheduling(void) {
+	static thread_local bool already_tried = false;
+	if (already_tried) {
+		return;
+	}
+	already_tried = true;
+
 	int priority = sched_get_priority_min(SCHED_RR);
 
 	if (rtkit_make_realtime(0, priority)) {

--- a/src/vblank.h
+++ b/src/vblank.h
@@ -40,8 +40,8 @@ typedef enum vblank_callback_action (*vblank_callback_t)(struct vblank_event *ev
 bool vblank_scheduler_schedule(struct vblank_scheduler *self, vblank_callback_t cb,
                                void *user_data);
 struct vblank_scheduler *
-vblank_scheduler_new(struct ev_loop *loop, struct x_connection *c,
-                     xcb_window_t target_window, enum vblank_scheduler_type type);
+vblank_scheduler_new(struct ev_loop *loop, struct x_connection *c, xcb_window_t target_window,
+                     enum vblank_scheduler_type type, bool use_realtime_scheduling);
 void vblank_scheduler_free(struct vblank_scheduler *);
 
 bool vblank_handle_x_events(struct vblank_scheduler *self);


### PR DESCRIPTION
And add a --realtime option for enabling it.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com><!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
