### PR TITLE
various fixes

### DIFF
--- a/src/backend/gl/shaders.c
+++ b/src/backend/gl/shaders.c
@@ -126,6 +126,8 @@ const char blit_shader_glsl[] = GLSL(330,
 	uniform sampler2D brightness;
 	layout(location = UNIFORM_MAX_BRIGHTNESS_LOC)
 	uniform float max_brightness;
+	layout(location = UNIFORM_TIME_LOC)
+	uniform float time;
 	// Signed distance field for rectangle center at (0, 0), with size of
 	// half_size * 2
 	float rectangle_sdf(vec2 point, vec2 half_size) {

--- a/src/picom.c
+++ b/src/picom.c
@@ -1900,6 +1900,7 @@ static void draw_callback(EV_P_ ev_timer *w, int revents) {
 
 	// Immediately start next frame if we are in benchmark mode.
 	if (ps->o.benchmark) {
+		ps->render_queued = true;
 		ev_timer_set(w, 0, 0);
 		ev_timer_start(EV_A_ w);
 	}
@@ -2711,6 +2712,7 @@ static void session_run(session_t *ps) {
 
 	// In benchmark mode, we want draw_timer handler to always be active
 	if (ps->o.benchmark) {
+		ps->render_queued = true;
 		ev_timer_set(&ps->draw_timer, 0, 0);
 		ev_timer_start(ps->loop, &ps->draw_timer);
 	} else {

--- a/src/picom.c
+++ b/src/picom.c
@@ -1895,8 +1895,11 @@ static void draw_callback_impl(EV_P_ session_t *ps, int revents attr_unused) {
 static void draw_callback(EV_P_ ev_timer *w, int revents) {
 	session_t *ps = session_ptr(w, draw_timer);
 
-	draw_callback_impl(EV_A_ ps, revents);
+	// The draw timer has to be stopped before calling the draw_callback_impl
+	// function because it may be set and started there, e.g. when a custom
+	// animated shader is used.
 	ev_timer_stop(EV_A_ w);
+	draw_callback_impl(EV_A_ ps, revents);
 
 	// Immediately start next frame if we are in benchmark mode.
 	if (ps->o.benchmark) {


### PR DESCRIPTION
### backend/gl: specify the time uniform location in blit_shader_glsl
to avoid breaking custom animated shaders by having to specify it
themselves.

### picom: fix the benchmark option
mimic the normal rendering routine by setting ps->render_queued to true
before setting and starting the draw timer.

### picom: fix custom animated shaders
the draw timer has to be stopped before calling the draw_callback_impl
function because when there's a custom animated shader it calls the
queue_redraw funtion that calls the schedule_render function that sets
and starts the draw timer that gets immediately stopped otherwise.

this fixes the screen not being redirected back with unredir-if-possible
and a custom animated shader and only the first frame being drawn with
vsync, no-frame-pacing and a custom animated shader.