### PR TITLE
common: remove OPENGL_MAX_DEPTH and it's uses

### DIFF
--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -371,12 +371,6 @@ static image_handle
 glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt) {
 	GLXPixmap *glxpixmap = NULL;
 	auto gd = (struct _glx_data *)base;
-	// Retrieve pixmap parameters, if they aren't provided
-	if (fmt.visual_depth > OPENGL_MAX_DEPTH) {
-		log_error("Requested depth %d higher than max possible depth %d.",
-		          fmt.visual_depth, OPENGL_MAX_DEPTH);
-		return NULL;
-	}
 
 	if (fmt.visual_depth < 0) {
 		log_error("Pixmap %#010x with invalid depth %d", pixmap, fmt.visual_depth);

--- a/src/common.h
+++ b/src/common.h
@@ -70,9 +70,6 @@
 #define US_PER_SEC 1000000L
 #define MS_PER_SEC 1000
 
-/// @brief Maximum OpenGL FBConfig depth.
-#define OPENGL_MAX_DEPTH 32
-
 /// @brief Maximum OpenGL buffer age.
 #define CGLX_MAX_BUFFER_AGE 5
 

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -746,11 +746,6 @@ bool glx_bind_pixmap(session_t *ps, glx_texture_t **pptex, xcb_pixmap_t pixmap, 
 				log_error("Failed to query info of pixmap %#010x.", pixmap);
 				return false;
 			}
-			if (r->depth > OPENGL_MAX_DEPTH) {
-				log_error("Requested depth %d higher than %d.", depth,
-				          OPENGL_MAX_DEPTH);
-				return false;
-			}
 			depth = r->depth;
 			width = r->width;
 			height = r->height;


### PR DESCRIPTION
### common: remove OPENGL_MAX_DEPTH and it's uses
scientists haven't proven the existence of depths greater than 32 yet.