### PR TITLE
options: refactor option parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 * Setting `--shadow-exclude-reg` is now a hard error. It was deprecated almost since the start of `picom`. `--clip-shadow-above` is the better alternative. (#1254)
 * Remove command line options `-n`, `-a`, and `-s`. They were removed more than 10 years ago, it's time to finally get rid of them entirely. (#1254)
+* Remove error message for `--glx-swap-method`, it was deprecated in v6.
+* Remove error message for passing argument to `--vsync` arguments, it was deprecated in v5.
+* Option `--opengl` is now deprecated, use `--backend=glx` instead.
 
 ## Bug fixes
 

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,8 @@ if get_option('warning_level') != '0'
             'nonnull', 'shadow', 'no-type-limits', 'old-style-declaration', 'override-init',
             'sign-compare', 'type-limits', 'uninitialized', 'shift-negative-value',
             'unused-but-set-parameter', 'unused-parameter', 'implicit-fallthrough=2',
-            'no-unknown-warning-option', 'no-missing-braces', 'conversion', 'empty-body' ]
+            'no-unknown-warning-option', 'no-missing-braces', 'conversion', 'empty-body',
+            'no-c2x-extensions' ]
   bad_warns_ubsan = [
     'no-format-overflow' # see gcc bug 87884, enabling UBSAN makes gcc spit out spurious warnings
                          # (if you saw this comment, went and checked gcc bugzilla, and found out

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -853,7 +853,7 @@ cdbus_process_opts_get(session_t *ps, DBusMessage *msg, DBusMessage *reply, DBus
 		dbus_set_error_const(err, DBUS_ERROR_INVALID_ARGS, NULL);
 		return DBUS_HANDLER_RESULT_HANDLED;
 	}
-	assert(ps->o.backend < sizeof(BACKEND_STRS) / sizeof(BACKEND_STRS[0]));
+	assert((size_t)ps->o.backend < sizeof(BACKEND_STRS) / sizeof(BACKEND_STRS[0]));
 
 #define append(tgt, type, ret)                                                           \
 	if (!strcmp(#tgt, target)) {                                                     \

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -173,17 +173,14 @@ int inspect_main(int argc, char **argv, const char *config_file) {
 
 	char *config_file_to_free = NULL;
 	struct options options;
-	bool shadow_enabled, fading_enable, hasneg;
-	win_option_mask_t winopt_mask[NUM_WINTYPES] = {0};
-	config_file = config_file_to_free = parse_config(
-	    &options, config_file, &shadow_enabled, &fading_enable, &hasneg, winopt_mask);
+	config_file = config_file_to_free = parse_config(&options, config_file);
 
 	if (IS_ERR(config_file_to_free)) {
 		return 1;
 	}
 
 	// Parse all of the rest command line options
-	if (!get_cfg(&options, argc, argv, shadow_enabled, fading_enable, hasneg, winopt_mask)) {
+	if (!get_cfg(&options, argc, argv)) {
 		log_fatal("Failed to get configuration, usually mean you have specified "
 		          "invalid options.");
 		return 1;

--- a/src/log.c
+++ b/src/log.c
@@ -78,7 +78,7 @@ static attr_const const char *log_level_to_string(enum log_level level) {
 	}
 }
 
-enum log_level string_to_log_level(const char *str) {
+int string_to_log_level(const char *str) {
 	if (strcasecmp(str, "TRACE") == 0) {
 		return LOG_LEVEL_TRACE;
 	}

--- a/src/log.h
+++ b/src/log.h
@@ -60,7 +60,7 @@ attr_nonnull_all void log_destroy(struct log *);
 attr_nonnull(1) void log_set_level(struct log *l, int level);
 attr_pure enum log_level log_get_level(const struct log *l);
 attr_nonnull_all void log_add_target(struct log *, struct log_target *);
-attr_pure enum log_level string_to_log_level(const char *);
+attr_pure int string_to_log_level(const char *);
 /// Remove a previously added log target for a log struct, and destroy it. If the log
 /// target was never added, nothing happens.
 void log_remove_target(struct log *l, struct log_target *tgt);

--- a/src/options.c
+++ b/src/options.c
@@ -17,184 +17,492 @@
 #include "config.h"
 #include "log.h"
 #include "options.h"
+#include "string_utils.h"
 #include "utils.h"
 #include "win.h"
 #include "x.h"
 
 #pragma GCC diagnostic error "-Wunused-parameter"
 
+struct picom_option;
+
+struct picom_arg {
+	const char *name;
+	ptrdiff_t offset;
+
+	const void *user_data;
+	bool (*handler)(const struct picom_option *, const struct picom_arg *,
+	                const char *optarg, void *output);
+};
+
+struct picom_arg_parser {
+	int (*parse)(const char *);
+	int invalid_value;
+};
+
+struct picom_rules_parser {
+	void *(*parse_prefix)(const char *, const char **end, void *data);
+	void (*free_value)(void *);
+	void *user_data;
+};
+
+struct picom_deprecated_arg {
+	const char *message;
+	struct picom_arg inner;
+	bool error;
+};
+
 struct picom_option {
 	const char *long_name;
 	int has_arg;
-	int val;
-	const char *arg_name;
+	struct picom_arg arg;
 	const char *help;
 };
+
+static bool set_flag(const struct picom_option * /*opt*/, const struct picom_arg *arg,
+                     const char * /*arg_str*/, void *output) {
+	*(bool *)(output + arg->offset) = true;
+	return true;
+}
+
+static bool unset_flag(const struct picom_option * /*opt*/, const struct picom_arg *arg,
+                       const char * /*arg_str*/, void *output) {
+	*(bool *)(output + arg->offset) = false;
+	return true;
+}
+
+static bool parse_with(const struct picom_option *opt, const struct picom_arg *arg,
+                       const char *arg_str, void *output) {
+	const struct picom_arg_parser *parser = arg->user_data;
+	int *dst = (int *)(output + arg->offset);
+	*dst = parser->parse(arg_str);
+	if (*dst == parser->invalid_value) {
+		log_error("Invalid argument for option `--%s`: %s", opt->long_name, arg_str);
+		return false;
+	}
+	return true;
+}
+
+static bool store_float(const struct picom_option *opt, const struct picom_arg *arg,
+                        const char *arg_str, void *output) {
+	double *dst = (double *)(output + arg->offset);
+	const double *minmax = (const double *)arg->user_data;
+	const char *endptr = NULL;
+	*dst = strtod_simple(arg_str, &endptr);
+	if (!endptr || *endptr != '\0') {
+		log_error("Argument for option `--%s` is not a valid float number: %s",
+		          opt->long_name, arg_str);
+		return false;
+	}
+	*dst = max2(minmax[0], min2(*dst, minmax[1]));
+	return true;
+}
+
+static bool store_int(const struct picom_option *opt, const struct picom_arg *arg,
+                      const char *arg_str, void *output) {
+	const int *minmax = (const int *)arg->user_data;
+	int *dst = (int *)(output + arg->offset);
+	if (!parse_int(arg_str, dst)) {
+		log_error("Argument for option `--%s` is not a valid integer: %s",
+		          opt->long_name, arg_str);
+		return false;
+	}
+	*dst = max2(minmax[0], min2(*dst, minmax[1]));
+	return true;
+}
+
+static bool store_string(const struct picom_option * /*opt*/, const struct picom_arg *arg,
+                         const char *arg_str, void *output) {
+	char **dst = (char **)(output + arg->offset);
+	free(*dst);
+	*dst = strdup(arg_str);
+	return true;
+}
+
+static bool store_rules(const struct picom_option * /*opt*/, const struct picom_arg *arg,
+                        const char *arg_str, void *output) {
+	const struct picom_rules_parser *parser = arg->user_data;
+	auto rules = (c2_lptr_t **)(output + arg->offset);
+	if (!parser->parse_prefix) {
+		return c2_parse(rules, arg_str, NULL) != NULL;
+	}
+	return c2_parse_with_prefix(rules, arg_str, parser->parse_prefix,
+	                            parser->free_value, parser->user_data);
+}
+
+static bool store_fixed_enum(const struct picom_option * /*opt*/, const struct picom_arg *arg,
+                             const char * /*arg_str*/, void *output) {
+	const int *value = (const int *)arg->user_data;
+	*(int *)(output + arg->offset) = *value;
+	return true;
+}
+
+static bool noop(const struct picom_option * /*opt*/, const struct picom_arg * /*arg*/,
+                 const char * /*arg_str*/, void * /*output*/) {
+	return true;
+}
+
+static bool reject(const struct picom_option * /*opt*/, const struct picom_arg * /*arg*/,
+                   const char * /*arg_str*/, void * /*output*/) {
+	return false;
+}
+
+static bool say_deprecated(const struct picom_option *opt, const struct picom_arg *arg,
+                           const char *arg_str, void *output) {
+	const struct picom_deprecated_arg *deprecation = arg->user_data;
+	enum log_level level = deprecation->error ? LOG_LEVEL_ERROR : LOG_LEVEL_WARN;
+	log_printf(tls_logger, level, __func__,
+	           "Option `--%s` has been deprecated. Please remove it. %s",
+	           opt->long_name, deprecation->message);
+	return deprecation->inner.handler(opt, &deprecation->inner, arg_str, output);
+}
+
+#define OFFSET(member) offsetof(struct options, member)
+
+#define ENABLE(member)                                                                   \
+	no_argument, {                                                                   \
+		.offset = OFFSET(member), .handler = set_flag,                           \
+	}
+
+#define DISABLE(member)                                                                  \
+	no_argument, {                                                                   \
+		.offset = OFFSET(member), .handler = unset_flag,                         \
+	}
+
+#define IGNORE(has_arg)                                                                  \
+	has_arg, {                                                                       \
+		.handler = noop,                                                         \
+	}
+
+#define REJECT(has_arg)                                                                  \
+	has_arg, {                                                                       \
+		.handler = reject,                                                       \
+	}
+
+#define DO(fn)                                                                           \
+	required_argument, {                                                             \
+		.handler = (fn),                                                         \
+	}
+
+#define PARSE_WITH(fn, invalid, member)                                                  \
+	required_argument, {                                                             \
+		.offset = OFFSET(member), .handler = parse_with,                         \
+		.user_data = (struct picom_arg_parser[]){{                               \
+		    .invalid_value = (invalid),                                          \
+		    .parse = (fn),                                                       \
+		}},                                                                      \
+	}
+
+#define FLOAT(member, min, max)                                                          \
+	required_argument, {                                                             \
+		.offset = OFFSET(member), .handler = store_float,                        \
+		.user_data = (double[]){min, max},                                       \
+	}
+
+#define INTEGER(member, min, max)                                                        \
+	required_argument, {                                                             \
+		.offset = OFFSET(member), .handler = store_int,                          \
+		.user_data = (int[]){min, max},                                          \
+	}
+
+#define NAMED_STRING(member, name_)                                                      \
+	required_argument, {                                                             \
+		.offset = OFFSET(member), .handler = store_string, .name = (name_)       \
+	}
+
+#define STRING(member) NAMED_STRING(member, NULL)
+
+#define NAMED_RULES(member, name_, ...)                                                  \
+	required_argument, {                                                             \
+		.offset = OFFSET(member), .handler = store_rules, .name = (name_),       \
+		.user_data = (struct picom_rules_parser[]) {                             \
+			__VA_ARGS__                                                      \
+		}                                                                        \
+	}
+#define NUMERIC_RULES(member, value, min, max)                                           \
+	NAMED_RULES(member, value ":COND",                                               \
+	            {.parse_prefix = parse_numeric_prefix, .user_data = (int[]){min, max}})
+#define RULES(member) NAMED_RULES(member, "COND", {})
+
+#define FIXED(member, value)                                                             \
+	no_argument, {                                                                   \
+		.offset = OFFSET(member), .handler = store_fixed_enum,                   \
+		.user_data = (int[]){value},                                             \
+	}
+
+#define SAY_DEPRECATED_(error_, msg, has_arg, ...)                                        \
+	has_arg, {                                                                        \
+		.handler = say_deprecated, .user_data = (struct picom_deprecated_arg[]) { \
+			{.message = (msg), .inner = __VA_ARGS__, .error = error_},        \
+		}                                                                         \
+	}
+#define SAY_DEPRECATED(error_, msg, ...) SAY_DEPRECATED_(error_, msg, __VA_ARGS__)
+
+#define WARN_DEPRECATED(...)                                                             \
+	SAY_DEPRECATED_(false,                                                           \
+	                "If you encounter problems without this feature, please "        \
+	                "feel free to open a bug report.",                               \
+	                __VA_ARGS__)
+
+#define WARN_DEPRECATED_ENABLED(...)                                                     \
+	SAY_DEPRECATED_(false, "Its functionality will always be enabled. ", __VA_ARGS__)
+
+#define ERROR_DEPRECATED(has_arg) SAY_DEPRECATED(true, "", REJECT(has_arg))
+
+static bool
+store_shadow_color(const struct picom_option * /*opt*/, const struct picom_arg * /*arg*/,
+                   const char *arg_str, void *output) {
+	struct options *opt = (struct options *)output;
+	struct color rgb;
+	rgb = hex_to_rgb(arg_str);
+	opt->shadow_red = rgb.red;
+	opt->shadow_green = rgb.green;
+	opt->shadow_blue = rgb.blue;
+	return true;
+}
+
+static bool
+handle_menu_opacity(const struct picom_option * /*opt*/, const struct picom_arg * /*arg*/,
+                    const char *arg_str, void *output) {
+	struct options *opt = (struct options *)output;
+	const char *endptr = NULL;
+	double tmp = max2(0.0, min2(1.0, strtod_simple(arg_str, &endptr)));
+	if (!endptr || *endptr != '\0') {
+		return false;
+	}
+	opt->wintype_option_mask[WINTYPE_DROPDOWN_MENU].opacity = true;
+	opt->wintype_option_mask[WINTYPE_POPUP_MENU].opacity = true;
+	opt->wintype_option[WINTYPE_POPUP_MENU].opacity = tmp;
+	opt->wintype_option[WINTYPE_DROPDOWN_MENU].opacity = tmp;
+	return true;
+}
+
+static bool
+store_blur_kern(const struct picom_option * /*opt*/, const struct picom_arg * /*arg*/,
+                const char *arg_str, void *output) {
+	struct options *opt = (struct options *)output;
+	opt->blur_kerns = parse_blur_kern_lst(arg_str, &opt->blur_kernel_count);
+	return opt->blur_kerns != NULL;
+}
+
+static bool
+store_benchmark_wid(const struct picom_option * /*opt*/, const struct picom_arg * /*arg*/,
+                    const char *arg_str, void *output) {
+	struct options *opt = (struct options *)output;
+	const char *endptr = NULL;
+	opt->benchmark_wid = (xcb_window_t)strtoul(arg_str, (char **)&endptr, 0);
+	if (!endptr || *endptr != '\0') {
+		log_error("Invalid window ID for `--benchmark-wid`: %s", arg_str);
+		return false;
+	}
+	return true;
+}
+
+#define WINDOW_SHADER_RULE                                                               \
+	{ .parse_prefix = parse_window_shader_prefix_with_cwd, .free_value = free, }
+
+#ifdef CONFIG_OPENGL
+#define BACKENDS "xrender, glx"
+#else
+#define BACKENDS "xrender"
+#endif
 
 // clang-format off
 static const struct option *longopts = NULL;
 static const struct picom_option picom_options[] = {
-    {"config"                      , required_argument, 256, NULL          , "Path to the configuration file."},
-    {"help"                        , no_argument      , 'h', NULL          , "Print this help message and exit."},
-    {"shadow-radius"               , required_argument, 'r', NULL          , "The blur radius for shadows. (default 12)"},
-    {"shadow-opacity"              , required_argument, 'o', NULL          , "The translucency for shadows. (default .75)"},
-    {"shadow-offset-x"             , required_argument, 'l', NULL          , "The left offset for shadows. (default -15)"},
-    {"shadow-offset-y"             , required_argument, 't', NULL          , "The top offset for shadows. (default -15)"},
-    {"fade-in-step"                , required_argument, 'I', NULL          , "Opacity change between steps while fading in. (default 0.028)"},
-    {"fade-out-step"               , required_argument, 'O', NULL          , "Opacity change between steps while fading out. (default 0.03)"},
-    {"fade-delta"                  , required_argument, 'D', NULL          , "The time between steps in a fade in milliseconds. (default 10)"},
-    {"menu-opacity"                , required_argument, 'm', NULL          , "The opacity for menus. (default 1.0)"},
-    {"shadow"                      , no_argument      , 'c', NULL          , "Enabled client-side shadows on windows."},
-    {"clear-shadow"                , no_argument      , 'z', NULL          , "Don't draw shadow behind the window."},
-    {"fading"                      , no_argument      , 'f', NULL          , "Fade windows in/out when opening/closing and when opacity changes, "
+    // As you can see, aligning this table is difficult...
+
+    // Rejected options, we shouldn't be able to reach `get_cfg` when these are set
+    ['h'] = {"help"   , REJECT(no_argument), "Print this help message and exit."},
+    [318] = {"version", REJECT(no_argument), "Print version number and exit."},
+
+    // Ignored options, these are already handled by `get_early_cfg`
+    [314] = {"show-all-xerrors", IGNORE(no_argument)},
+    ['b'] = {"daemon"          , IGNORE(no_argument)      , "Daemonize process."},
+    [256] = {"config"          , IGNORE(required_argument), "Path to the configuration file."},
+
+    // Simple flags
+    ['c'] = {"shadow"                   , ENABLE(shadow_enable)            , "Enabled client-side shadows on windows."},
+    ['f'] = {"fading"                   , ENABLE(fading_enable)            , "Fade windows in/out when opening/closing and when opacity changes, "
                                                                              "unless --no-fading-openclose is used."},
-    {"inactive-opacity"            , required_argument, 'i', NULL          , "Opacity of inactive windows. (0.1 - 1.0)"},
-    {"frame-opacity"               , required_argument, 'e', NULL          , "Opacity of window titlebars and borders. (0.1 - 1.0)"},
-    {"daemon"                      , no_argument      , 'b', NULL          , "Daemonize process."},
-    {"shadow-red"                  , required_argument, 257, NULL          , "Red color value of shadow (0.0 - 1.0, defaults to 0)."},
-    {"shadow-green"                , required_argument, 258, NULL          , "Green color value of shadow (0.0 - 1.0, defaults to 0)."},
-    {"shadow-blue"                 , required_argument, 259, NULL          , "Blue color value of shadow (0.0 - 1.0, defaults to 0)."},
-    {"inactive-opacity-override"   , no_argument      , 260, NULL          , "Inactive opacity set by -i overrides value of _NET_WM_WINDOW_OPACITY."},
-    {"inactive-dim"                , required_argument, 261, NULL          , "Dim inactive windows. (0.0 - 1.0, defaults to 0)"},
-    {"mark-wmwin-focused"          , no_argument      , 262, NULL          , "Try to detect WM windows and mark them as active."},
-    {"shadow-exclude"              , required_argument, 263, NULL          , "Exclude conditions for shadows."},
-    {"mark-ovredir-focused"        , no_argument      , 264, NULL          , "Mark windows that have no WM frame as active."},
-    {"no-fading-openclose"         , no_argument      , 265, NULL          , "Do not fade on window open/close."},
-    {"shadow-ignore-shaped"        , no_argument      , 266, NULL          , "Do not paint shadows on shaped windows. (Deprecated, use --shadow-exclude "
+    [262] = {"mark-wmwin-focused"       , ENABLE(mark_wmwin_focused)       , "Try to detect WM windows and mark them as active."},
+    [264] = {"mark-ovredir-focused"     , ENABLE(mark_ovredir_focused)     , "Mark windows that have no WM frame as active."},
+    [265] = {"no-fading-openclose"      , ENABLE(no_fading_openclose)      , "Do not fade on window open/close."},
+    [266] = {"shadow-ignore-shaped"     , ENABLE(shadow_ignore_shaped)     , "Do not paint shadows on shaped windows. (Deprecated, use --shadow-exclude "
                                                                              "\'bounding_shaped\' or --shadow-exclude \'bounding_shaped && "
                                                                              "!rounded_corners\' instead.)"},
-    {"detect-rounded-corners"      , no_argument      , 267, NULL          , "Try to detect windows with rounded corners and don't consider them shaped "
-                                                                             "windows. Affects --shadow-ignore-shaped, --unredir-if-possible, and "
-                                                                             "possibly others. You need to turn this on manually if you want to match "
-                                                                             "against rounded_corners in conditions."},
-    {"detect-client-opacity"       , no_argument      , 268, NULL          , "Detect _NET_WM_WINDOW_OPACITY on client windows, useful for window "
+    [268] = {"detect-client-opacity"    , ENABLE(detect_client_opacity)    , "Detect _NET_WM_WINDOW_OPACITY on client windows, useful for window "
                                                                              "managers not passing _NET_WM_WINDOW_OPACITY of client windows to frame"},
-    {"refresh-rate"                , required_argument, 269, NULL          , NULL},
-    {"vsync"                       , optional_argument, 270, NULL          , "Enable VSync"},
-    {"crop-shadow-to-monitor"      , no_argument      , 271, NULL          , "Crop shadow of a window fully on a particular monitor to that monitor. "
+    [270] = {"vsync"                    , ENABLE(vsync)                    , "Enable VSync"},
+    [271] = {"crop-shadow-to-monitor"   , ENABLE(crop_shadow_to_monitor)   , "Crop shadow of a window fully on a particular monitor to that monitor. "
                                                                              "This is currently implemented using the X RandR extension"},
-    {"xinerama-shadow-crop"        , no_argument      , 272, NULL          , NULL},
-    {"sw-opti"                     , no_argument      , 274, NULL          , NULL},
-    {"vsync-aggressive"            , no_argument      , 275, NULL          , NULL},
-    {"use-ewmh-active-win"         , no_argument      , 276, NULL          , "Use _NET_WM_ACTIVE_WINDOW on the root window to determine which window is "
+    [276] = {"use-ewmh-active-win"      , ENABLE(use_ewmh_active_win)      , "Use _NET_WM_ACTIVE_WINDOW on the root window to determine which window is "
                                                                              "focused instead of using FocusIn/Out events"},
-    {"respect-prop-shadow"         , no_argument      , 277, NULL          , NULL},
-    {"unredir-if-possible"         , no_argument      , 278, NULL          , "Unredirect all windows if a full-screen opaque window is detected, to "
+    [278] = {"unredir-if-possible"      , ENABLE(unredir_if_possible)      , "Unredirect all windows if a full-screen opaque window is detected, to "
                                                                              "maximize performance for full-screen applications."},
-    {"focus-exclude"               , required_argument, 279, "COND"        , "Specify a list of conditions of windows that should always be considered focused."},
-    {"inactive-dim-fixed"          , no_argument      , 280, NULL          , "Use fixed inactive dim value."},
-    {"detect-transient"            , no_argument      , 281, NULL          , "Use WM_TRANSIENT_FOR to group windows, and consider windows in the same "
+    [280] = {"inactive-dim-fixed"       , ENABLE(inactive_dim_fixed)       , "Use fixed inactive dim value."},
+    [281] = {"detect-transient"         , ENABLE(detect_transient)         , "Use WM_TRANSIENT_FOR to group windows, and consider windows in the same "
                                                                              "group focused at the same time."},
-    {"detect-client-leader"        , no_argument      , 282, NULL          , "Use WM_CLIENT_LEADER to group windows, and consider windows in the same group "
+    [282] = {"detect-client-leader"     , ENABLE(detect_client_leader)     , "Use WM_CLIENT_LEADER to group windows, and consider windows in the same group "
                                                                              "focused at the same time. This usually means windows from the same application "
                                                                              "will be considered focused or unfocused at the same time. WM_TRANSIENT_FOR has "
                                                                              "higher priority if --detect-transient is enabled, too."},
-    {"blur-background"             , no_argument      , 283, NULL          , "Blur background of semi-transparent / ARGB windows. May impact performance"},
-    {"blur-background-frame"       , no_argument      , 284, NULL          , "Blur background of windows when the window frame is not opaque. Implies "
+    [284] = {"blur-background-frame"    , ENABLE(blur_background_frame)    , "Blur background of windows when the window frame is not opaque. Implies "
                                                                              "--blur-background."},
-    {"blur-background-fixed"       , no_argument      , 285, NULL          , "Use fixed blur strength instead of adjusting according to window opacity."},
+    [285] = {"blur-background-fixed"    , ENABLE(blur_background_fixed)    , "Use fixed blur strength instead of adjusting according to window opacity."},
 #ifdef CONFIG_DBUS
-    {"dbus"                        , no_argument      , 286, NULL          , "Enable remote control via D-Bus. See the D-BUS API section in the man page "
+    [286] = {"dbus"                     , ENABLE(dbus)                     , "Enable remote control via D-Bus. See the D-BUS API section in the man page "
                                                                              "for more details."},
 #endif
-    {"logpath"                     , required_argument, 287, NULL          , NULL},
-    {"invert-color-include"        , required_argument, 288, "COND"        , "Specify a list of conditions of windows that should be painted with "
-                                                                             "inverted color."},
-    {"opengl"                      , no_argument      , 289, NULL          , NULL},
-    {"backend"                     , required_argument, 290, NULL          , "Backend. Possible values are: xrender"
-#ifdef CONFIG_OPENGL
-                                                                             ", glx"
-#endif
-                                                                            },
-    {"glx-no-stencil"              , no_argument      , 291, NULL          , NULL},
-    {"benchmark"                   , required_argument, 293, NULL          , "Benchmark mode. Repeatedly paint until reaching the specified cycles."},
-    {"benchmark-wid"               , required_argument, 294, NULL          , "Specify window ID to repaint in benchmark mode. If omitted or is 0, the whole"
-                                                                             " screen is repainted."},
-    {"blur-background-exclude"     , required_argument, 296, "COND"        , "Exclude conditions for background blur."},
-    {"active-opacity"              , required_argument, 297, NULL          , "Default opacity for active windows. (0.0 - 1.0)"},
-    {"glx-no-rebind-pixmap"        , no_argument      , 298, NULL          , NULL},
-    {"glx-swap-method"             , required_argument, 299, NULL          , NULL},
-    {"fade-exclude"                , required_argument, 300, "COND"        , "Exclude conditions for fading."},
-    {"blur-kern"                   , required_argument, 301, NULL          , "Specify the blur convolution kernel, see man page for more details"},
-    {"resize-damage"               , required_argument, 302, NULL          , NULL}, // only used by legacy backends
-    {"glx-use-gpushader4"          , no_argument      , 303, NULL          , NULL},
-    {"opacity-rule"                , required_argument, 304, "OPACITY:COND", "Specify a list of opacity rules, see man page for more details"},
-    {"shadow-exclude-reg"          , required_argument, 305, NULL          , NULL},
-    {"paint-exclude"               , required_argument, 306, NULL          , NULL},
-    {"unredir-if-possible-exclude" , required_argument, 308, "COND"        , "Conditions of windows that shouldn't be considered full-screen for "
-                                                                             "unredirecting screen."},
-    {"unredir-if-possible-delay"   , required_argument, 309, NULL,           "Delay before unredirecting the window, in milliseconds. Defaults to 0."},
-    {"write-pid-path"              , required_argument, 310, "PATH"        , "Write process ID to a file."},
-    {"vsync-use-glfinish"          , no_argument      , 311, NULL          , NULL},
-    {"xrender-sync-fence"          , no_argument      , 313, NULL          , "Additionally use X Sync fence to sync clients' draw calls. Needed on "
+    [311] = {"vsync-use-glfinish"       , ENABLE(vsync_use_glfinish)},
+    [313] = {"xrender-sync-fence"       , ENABLE(xrender_sync_fence)       , "Additionally use X Sync fence to sync clients' draw calls. Needed on "
                                                                              "nvidia-drivers with GLX backend for some users."},
-    {"show-all-xerrors"            , no_argument      , 314, NULL          , NULL},
-    {"no-fading-destroyed-argb"    , no_argument      , 315, NULL          , "Do not fade destroyed ARGB windows with WM frame. Workaround bugs in Openbox, "
+    [315] = {"no-fading-destroyed-argb" , ENABLE(no_fading_destroyed_argb) , "Do not fade destroyed ARGB windows with WM frame. Workaround bugs in Openbox, "
                                                                              "Fluxbox, etc."},
-    {"force-win-blend"             , no_argument      , 316, NULL          , "Force all windows to be painted with blending. Useful if you have a custom "
+    [316] = {"force-win-blend"          , ENABLE(force_win_blend)          , "Force all windows to be painted with blending. Useful if you have a custom "
                                                                              "shader that could turn opaque pixels transparent."},
-    {"glx-fshader-win"             , required_argument, 317, NULL          , NULL},
-    {"version"                     , no_argument      , 318, NULL          , "Print version number and exit."},
-    {"no-x-selection"              , no_argument      , 319, NULL          , NULL},
-    {"log-level"                   , required_argument, 321, NULL          , "Log level, possible values are: trace, debug, info, warn, error"},
-    {"log-file"                    , required_argument, 322, NULL          , "Path to the log file."},
-    {"use-damage"                  , no_argument      , 323, NULL          , "Render only the damaged (changed) part of the screen"},
-    {"no-use-damage"               , no_argument      , 324, NULL          , "Disable the use of damage information. This cause the whole screen to be"
+    [319] = {"no-x-selection"           , ENABLE(no_x_selection)},
+    [323] = {"use-damage"               , ENABLE(use_damage)               , "Render only the damaged (changed) part of the screen"},
+    [324] = {"no-use-damage"            , DISABLE(use_damage)              , "Disable the use of damage information. This cause the whole screen to be"
                                                                              "redrawn every time, instead of the part of the screen that has actually "
                                                                              "changed. Potentially degrades the performance, but might fix some artifacts."},
-    {"no-vsync"                    , no_argument      , 325, NULL          , "Disable VSync"},
-    {"max-brightness"              , required_argument, 326, NULL          , "Dims windows which average brightness is above this threshold. Requires "
-                                                                             "--no-use-damage. (default: 1.0, meaning no dimming)"},
-    {"transparent-clipping"        , no_argument      , 327, NULL          , "Make transparent windows clip other windows like non-transparent windows do, "
+    [260] = {"inactive-opacity-override", ENABLE(inactive_opacity_override), "Inactive opacity set by -i overrides value of _NET_WM_WINDOW_OPACITY."},
+    [267] = {"detect-rounded-corners"   , ENABLE(detect_rounded_corners)   , "Try to detect windows with rounded corners and don't consider them shaped "
+                                                                             "windows. Affects --shadow-ignore-shaped, --unredir-if-possible, and "
+                                                                             "possibly others. You need to turn this on manually if you want to match "
+                                                                             "against rounded_corners in conditions."},
+    [298] = {"glx-no-rebind-pixmap"     , ENABLE(glx_no_rebind_pixmap)},
+    [291] = {"glx-no-stencil"           , ENABLE(glx_no_stencil)},
+    [325] = {"no-vsync"                 , DISABLE(vsync)                   , "Disable VSync"},
+    [327] = {"transparent-clipping"     , ENABLE(transparent_clipping)     , "Make transparent windows clip other windows like non-transparent windows do, "
                                                                              "instead of blending on top of them"},
-    {"transparent-clipping-exclude", required_argument, 338, "COND"        , "Specify a list of conditions of windows that should never have "
-                                                                             "transparent clipping applied. Useful for screenshot tools, where you "
-                                                                             "need to be able to see through transparent parts of the window."},
-    {"blur-method"                 , required_argument, 328, NULL          , "The algorithm used for background bluring. Available choices are: 'none' to "
-                                                                             "disable, 'gaussian', 'box' or 'kernel' for custom convolution blur with "
-                                                                             "--blur-kern. Note: 'gaussian' and 'box' is not supported by --legacy-backends."},
-    {"blur-size"                   , required_argument, 329, NULL          , "The radius of the blur kernel for 'box' and 'gaussian' blur method."},
-    {"blur-deviation"              , required_argument, 330, NULL          , "The standard deviation for the 'gaussian' blur method."},
-    {"blur-strength"               , required_argument, 331, NULL          , "The strength level of the 'dual_kawase' blur method."},
-    {"shadow-color"                , required_argument, 332, NULL          , "Color of shadow, as a hex RGB string (defaults to #000000)"},
-    {"corner-radius"               , required_argument, 333, NULL          , "Sets the radius of rounded window corners. When > 0, the compositor will "
-                                                                             "round the corners of windows. (defaults to 0)."},
-    {"rounded-corners-exclude"     , required_argument, 334, "COND"        , "Exclude conditions for rounded corners."},
-    {"corner-radius-rules"         , required_argument, 340, "RADIUS:COND" , "Window rules for specific rounded corner radii."},
-    {"clip-shadow-above"           , required_argument, 335, NULL          , "Specify a list of conditions of windows to not paint a shadow over, such "
-                                                                             "as a dock window."},
-    {"window-shader-fg"            , required_argument, 336, "PATH"        , "Specify GLSL fragment shader path for rendering window contents. Does not"
-                                                                             " work when `--legacy-backends` is enabled. See man page for more details."},
-    {"window-shader-fg-rule"       , required_argument, 337, "PATH:COND"   , "Specify GLSL fragment shader path for rendering window contents using "
-                                                                             "patterns. Pattern should be in the format of SHADER_PATH:PATTERN, "
-                                                                             "similar to --opacity-rule. SHADER_PATH can be \"default\", in which case "
-                                                                             "the default shader will be used. Does not work when --legacy-backends is "
-                                                                             "enabled. See man page for more details"},
-    // 338 is transparent-clipping-exclude
-    {"dithered-present"            , no_argument      , 339, NULL          , "Use higher precision during rendering, and apply dither when presenting the "
+    [339] = {"dithered-present"         , ENABLE(dithered_present)         , "Use higher precision during rendering, and apply dither when presenting the "
                                                                              "rendered screen. Reduces banding artifacts, but might cause performance "
                                                                              "degradation. Only works with OpenGL."},
-    // 340 is corner-radius-rules
-    {"no-frame-pacing"             , no_argument      , 341, NULL          , "Disable frame pacing. This might increase the latency."},
-    {"legacy-backends"             , no_argument      , 733, NULL          , "Use deprecated version of the backends."},
-    {"monitor-repaint"             , no_argument      , 800, NULL          , "Highlight the updated area of the screen. For debugging."},
-    {"diagnostics"                 , no_argument      , 801, NULL          , "Print diagnostic information"},
-    {"debug-mode"                  , no_argument      , 802, NULL          , "Render into a separate window, and don't take over the screen. Useful when "
+    [341] = {"no-frame-pacing"          , DISABLE(frame_pacing)            , "Disable frame pacing. This might increase the latency."},
+    [733] = {"legacy-backends"          , ENABLE(legacy_backends)          , "Use deprecated version of the backends."},
+    [800] = {"monitor-repaint"          , ENABLE(monitor_repaint)          , "Highlight the updated area of the screen. For debugging."},
+    [801] = {"diagnostics"              , ENABLE(print_diagnostics)        , "Print diagnostic information"},
+    [802] = {"debug-mode"               , ENABLE(debug_mode)               , "Render into a separate window, and don't take over the screen. Useful when "
                                                                              "you want to attach a debugger to picom"},
-    {"no-ewmh-fullscreen"          , no_argument      , 803, NULL          , "Do not use EWMH to detect fullscreen windows. Reverts to checking if a "
+    [803] = {"no-ewmh-fullscreen"       , ENABLE(no_ewmh_fullscreen)       , "Do not use EWMH to detect fullscreen windows. Reverts to checking if a "
                                                                              "window is fullscreen based only on its size and coordinates."},
-    {"realtime"                    , no_argument      , 804, NULL          , "Enable realtime scheduling. This might reduce latency, but might also cause "
+    [804] = {"realtime"                 , ENABLE(use_realtime_scheduling)  , "Enable realtime scheduling. This might reduce latency, but might also cause "
                                                                              "other issues. Disable this if you see the compositor being killed."},
+
+    // Flags that takes an argument
+    ['r'] = {"shadow-radius"               , INTEGER(shadow_radius, 0, INT_MAX)             , "The blur radius for shadows. (default 12)"},
+    ['o'] = {"shadow-opacity"              , FLOAT(shadow_opacity, 0, 1)                    , "The translucency for shadows. (default .75)"},
+    ['l'] = {"shadow-offset-x"             , INTEGER(shadow_offset_x, INT_MIN, INT_MAX)     , "The left offset for shadows. (default -15)"},
+    ['t'] = {"shadow-offset-y"             , INTEGER(shadow_offset_y, INT_MIN, INT_MAX)     , "The top offset for shadows. (default -15)"},
+    ['I'] = {"fade-in-step"                , FLOAT(fade_in_step, 0, 1)                      , "Opacity change between steps while fading in. (default 0.028)"},
+    ['O'] = {"fade-out-step"               , FLOAT(fade_out_step, 0, 1)                     , "Opacity change between steps while fading out. (default 0.03)"},
+    ['D'] = {"fade-delta"                  , INTEGER(fade_delta, 1, INT_MAX)                , "The time between steps in a fade in milliseconds. (default 10)"},
+    ['i'] = {"inactive-opacity"            , FLOAT(inactive_opacity, 0, 1)                  , "Opacity of inactive windows. (0.0 - 1.0)"},
+    ['e'] = {"frame-opacity"               , FLOAT(frame_opacity, 0, 1)                     , "Opacity of window titlebars and borders. (0.0 - 1.0)"},
+    [257] = {"shadow-red"                  , FLOAT(shadow_red, 0, 1)                        , "Red color value of shadow (0.0 - 1.0, defaults to 0)."},
+    [258] = {"shadow-green"                , FLOAT(shadow_green, 0, 1)                      , "Green color value of shadow (0.0 - 1.0, defaults to 0)."},
+    [259] = {"shadow-blue"                 , FLOAT(shadow_blue, 0, 1)                       , "Blue color value of shadow (0.0 - 1.0, defaults to 0)."},
+    [261] = {"inactive-dim"                , FLOAT(inactive_dim, 0, 1)                      , "Dim inactive windows. (0.0 - 1.0, defaults to 0)"},
+    [283] = {"blur-background"             , FIXED(blur_method, BLUR_METHOD_KERNEL)         , "Blur background of semi-transparent / ARGB windows. May impact performance"},
+    [290] = {"backend"                     , PARSE_WITH(parse_backend, NUM_BKEND, backend)  , "Backend. Possible values are: " BACKENDS},
+    [293] = {"benchmark"                   , INTEGER(benchmark, 0, INT_MAX)                 , "Benchmark mode. Repeatedly paint until reaching the specified cycles."},
+    [297] = {"active-opacity"              , FLOAT(active_opacity, 0, 1)                    , "Default opacity for active windows. (0.0 - 1.0)"},
+    [302] = {"resize-damage"               , INTEGER(resize_damage, INT_MIN, INT_MAX)},       // only used by legacy backends
+    [309] = {"unredir-if-possible-delay"   , INTEGER(unredir_if_possible_delay, 0, INT_MAX) , "Delay before unredirecting the window, in milliseconds. Defaults to 0."},
+    [310] = {"write-pid-path"              , NAMED_STRING(write_pid_path, "PATH")           , "Write process ID to a file."},
+    [317] = {"glx-fshader-win"             , STRING(glx_fshader_win_str)},
+    [322] = {"log-file"                    , STRING(logpath)                                , "Path to the log file."},
+    [326] = {"max-brightness"              , FLOAT(max_brightness, 0, 1)                    , "Dims windows which average brightness is above this threshold. Requires "
+                                                                                              "--no-use-damage. (default: 1.0, meaning no dimming)"},
+    [329] = {"blur-size"                   , INTEGER(blur_radius, 0, INT_MAX)               , "The radius of the blur kernel for 'box' and 'gaussian' blur method."},
+    [330] = {"blur-deviation"              , FLOAT(blur_deviation, 0, INFINITY)             , "The standard deviation for the 'gaussian' blur method."},
+    [331] = {"blur-strength"               , INTEGER(blur_strength, 0, INT_MAX)             , "The strength level of the 'dual_kawase' blur method."},
+    [333] = {"corner-radius"               , INTEGER(corner_radius, 0, INT_MAX)             , "Sets the radius of rounded window corners. When > 0, the compositor will "
+                                                                                              "round the corners of windows. (defaults to 0)."},
+    [336] = {"window-shader-fg"            , NAMED_STRING(window_shader_fg, "PATH")         , "Specify GLSL fragment shader path for rendering window contents. Does not"
+                                                                                              " work when `--legacy-backends` is enabled. See man page for more details."},
+    [294] = {"benchmark-wid"               , DO(store_benchmark_wid)                        , "Specify window ID to repaint in benchmark mode. If omitted or is 0, the whole"
+                                                                                              " screen is repainted."},
+    [301] = {"blur-kern"                   , DO(store_blur_kern)                            , "Specify the blur convolution kernel, see man page for more details"},
+    [332] = {"shadow-color"                , DO(store_shadow_color)                         , "Color of shadow, as a hex RGB string (defaults to #000000)"},
+
+    // Rules
+    [263] = {"shadow-exclude"              , RULES(shadow_blacklist)              , "Exclude conditions for shadows."},
+    [279] = {"focus-exclude"               , RULES(focus_blacklist)               , "Specify a list of conditions of windows that should always be considered focused."},
+    [288] = {"invert-color-include"        , RULES(invert_color_list)             , "Specify a list of conditions of windows that should be painted with "
+                                                                                    "inverted color."},
+    [296] = {"blur-background-exclude"     , RULES(blur_background_blacklist)     , "Exclude conditions for background blur."},
+    [300] = {"fade-exclude"                , RULES(fade_blacklist)                , "Exclude conditions for fading."},
+    [306] = {"paint-exclude"               , RULES(paint_blacklist)               , NULL},
+    [308] = {"unredir-if-possible-exclude" , RULES(unredir_if_possible_blacklist) , "Conditions of windows that shouldn't be considered full-screen for "
+                                                                                    "unredirecting screen."},
+    [334] = {"rounded-corners-exclude"     , RULES(rounded_corners_blacklist)     , "Exclude conditions for rounded corners."},
+    [335] = {"clip-shadow-above"           , RULES(shadow_clip_list)              , "Specify a list of conditions of windows to not paint a shadow over, such "
+                                                                                    "as a dock window."},
+    [338] = {"transparent-clipping-exclude", RULES(transparent_clipping_blacklist), "Specify a list of conditions of windows that should never have "
+                                                                                    "transparent clipping applied. Useful for screenshot tools, where you "
+                                                                                    "need to be able to see through transparent parts of the window."},
+
+    // Rules that are too long to fit in one line
+    [304] = {"opacity-rule"                , NUMERIC_RULES(opacity_rules, "OPACITY", 0, 100),
+             "Specify a list of opacity rules, see man page for more details"},
+    [337] = {"window-shader-fg-rule"       , NAMED_RULES(window_shader_fg_rules, "PATH", WINDOW_SHADER_RULE),
+             "Specify GLSL fragment shader path for rendering window contents using patterns. Pattern should be "
+             "in the format of SHADER_PATH:PATTERN, similar to --opacity-rule. SHADER_PATH can be \"default\", "
+             "in which case the default shader will be used. Does not work when --legacy-backends is enabled. See "
+             "man page for more details"},
+    [340] = {"corner-radius-rules"         , NUMERIC_RULES(corner_radius_rules, "RADIUS", 0, INT_MAX),
+             "Window rules for specific rounded corner radii."},
+
+    // Options that are too long to fit in one line
+    [321] = {"log-level"  , PARSE_WITH(string_to_log_level, LOG_LEVEL_INVALID, log_level),
+             "Log level, possible values are: trace, debug, info, warn, error"},
+    [328] = {"blur-method", PARSE_WITH(parse_blur_method, BLUR_METHOD_INVALID, blur_method),
+             "The algorithm used for background bluring. Available choices are: 'none' to disable, 'gaussian', "
+	     "'box' or 'kernel' for custom convolution blur with --blur-kern. Note: 'gaussian' and 'box' is not "
+	     "supported by --legacy-backends."},
+
+    // Deprecated options
+    [274] = {"sw-opti"            , ERROR_DEPRECATED(no_argument)},
+    [275] = {"vsync-aggressive"   , ERROR_DEPRECATED(no_argument)},
+    [277] = {"respect-prop-shadow", ERROR_DEPRECATED(no_argument)},
+    [303] = {"glx-use-gpushader4" , ERROR_DEPRECATED(no_argument)},
+    [269] = {"refresh-rate"       , WARN_DEPRECATED(IGNORE(required_argument))},
+
+    // Deprecated options with messages
+#define CLEAR_SHADOW_DEPRECATION                                                         \
+	"Shadows are automatically cleared now. If you want to prevent shadow from "     \
+	"being cleared under certain types of windows, you can use the \"full-shadow\" " \
+	"window type option."
+
+#define MENU_OPACITY_DEPRECATION                                                         \
+	"Use the wintype option `opacity` of `popup_menu` and `dropdown_menu` instead."
+
+    ['m'] = {"menu-opacity"        , SAY_DEPRECATED(false, MENU_OPACITY_DEPRECATION               , DO(handle_menu_opacity))},
+    ['z'] = {"clear-shadow"        , SAY_DEPRECATED(false, CLEAR_SHADOW_DEPRECATION               , IGNORE(no_argument))},
+    [272] = {"xinerama-shadow-crop", SAY_DEPRECATED(false, "Use --crop-shadow-to-monitor instead.", ENABLE(crop_shadow_to_monitor))},
+    [287] = {"logpath"             , SAY_DEPRECATED(false, "Use --log-file instead."              , STRING(logpath))},
+    [289] = {"opengl"              , SAY_DEPRECATED(false, "Use --backend=glx instead."           , FIXED(backend, BKEND_GLX))},
+    [305] = {"shadow-exclude-reg"  , SAY_DEPRECATED(true,  "Use --clip-shadow-above instead."     , REJECT(required_argument))},
+
+#undef CLEAR_SHADOW_DEPRECATION
+#undef MENU_OPACITY_DEPRECATION
 };
 // clang-format on
 
 static void setup_longopts(void) {
 	auto opts = ccalloc(ARR_SIZE(picom_options) + 1, struct option);
+	int option_count = 0;
 	for (size_t i = 0; i < ARR_SIZE(picom_options); i++) {
-		opts[i].name = picom_options[i].long_name;
-		opts[i].has_arg = picom_options[i].has_arg;
-		opts[i].flag = NULL;
-		opts[i].val = picom_options[i].val;
+		if (picom_options[i].arg.handler == NULL) {
+			continue;
+		}
+		opts[option_count].name = picom_options[i].long_name;
+		opts[option_count].has_arg = picom_options[i].has_arg;
+		opts[option_count].flag = NULL;
+		opts[option_count].val = (int)i;
+		option_count++;
 	}
 	longopts = opts;
 }
@@ -273,8 +581,8 @@ static void usage(const char *argv0, int ret) {
 			continue;
 		}
 		auto option_len = strlen(picom_options[i].long_name) + 2 + 4;
-		if (picom_options[i].arg_name) {
-			option_len += strlen(picom_options[i].arg_name) + 1;
+		if (picom_options[i].arg.name) {
+			option_len += strlen(picom_options[i].arg.name) + 1;
 		}
 		if (option_len > help_indent && option_len < 30) {
 			help_indent = option_len;
@@ -288,22 +596,78 @@ static void usage(const char *argv0, int ret) {
 		}
 		size_t option_len = 8;
 		fprintf(f, "    ");
-		if ((picom_options[i].val > 'a' && picom_options[i].val < 'z') ||
-		    (picom_options[i].val > 'A' && picom_options[i].val < 'Z')) {
-			fprintf(f, "-%c, ", picom_options[i].val);
+		if ((i > 'a' && i < 'z') || (i > 'A' && i < 'Z')) {
+			fprintf(f, "-%c, ", (char)i);
 		} else {
 			fprintf(f, "    ");
 		}
 		fprintf(f, "--%s", picom_options[i].long_name);
 		option_len += strlen(picom_options[i].long_name) + 2;
-		if (picom_options[i].arg_name) {
-			fprintf(f, "=%s", picom_options[i].arg_name);
-			option_len += strlen(picom_options[i].arg_name) + 1;
+		if (picom_options[i].arg.name) {
+			fprintf(f, "=%s", picom_options[i].arg.name);
+			option_len += strlen(picom_options[i].arg.name) + 1;
 		}
 		fprintf(f, "  ");
 		option_len += 2;
 		print_help(picom_options[i].help, help_indent, option_len,
 		           (size_t)line_wrap, f);
+	}
+}
+
+static void set_default_winopts(options_t *opt) {
+	auto mask = opt->wintype_option_mask;
+	// Apply default wintype options.
+	if (!mask[WINTYPE_DESKTOP].shadow) {
+		// Desktop windows are always drawn without shadow by default.
+		mask[WINTYPE_DESKTOP].shadow = true;
+		opt->wintype_option[WINTYPE_DESKTOP].shadow = false;
+	}
+
+	// Focused/unfocused state only apply to a few window types, all other windows
+	// are always considered focused.
+	const wintype_t nofocus_type[] = {WINTYPE_UNKNOWN, WINTYPE_NORMAL, WINTYPE_UTILITY};
+	for (unsigned long i = 0; i < ARR_SIZE(nofocus_type); i++) {
+		if (!mask[nofocus_type[i]].focus) {
+			mask[nofocus_type[i]].focus = true;
+			opt->wintype_option[nofocus_type[i]].focus = false;
+		}
+	}
+	for (unsigned long i = 0; i < NUM_WINTYPES; i++) {
+		if (!mask[i].shadow) {
+			mask[i].shadow = true;
+			opt->wintype_option[i].shadow = opt->shadow_enable;
+		}
+		if (!mask[i].fade) {
+			mask[i].fade = true;
+			opt->wintype_option[i].fade = opt->fading_enable;
+		}
+		if (!mask[i].focus) {
+			mask[i].focus = true;
+			opt->wintype_option[i].focus = true;
+		}
+		if (!mask[i].blur_background) {
+			mask[i].blur_background = true;
+			opt->wintype_option[i].blur_background =
+			    opt->blur_method != BLUR_METHOD_NONE;
+		}
+		if (!mask[i].full_shadow) {
+			mask[i].full_shadow = true;
+			opt->wintype_option[i].full_shadow = false;
+		}
+		if (!mask[i].redir_ignore) {
+			mask[i].redir_ignore = true;
+			opt->wintype_option[i].redir_ignore = false;
+		}
+		if (!mask[i].opacity) {
+			mask[i].opacity = true;
+			// Opacity is not set to a concrete number here because the
+			// opacity logic is complicated, and needs an "unset" state
+			opt->wintype_option[i].opacity = NAN;
+		}
+		if (!mask[i].clip_shadow_above) {
+			mask[i].clip_shadow_above = true;
+			opt->wintype_option[i].clip_shadow_above = false;
+		}
 	}
 }
 
@@ -360,395 +724,18 @@ err:
 /**
  * Process arguments and configuration files.
  */
-bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
-             bool fading_enable, bool conv_kern_hasneg, win_option_mask_t *winopt_mask) {
-
+bool get_cfg(options_t *opt, int argc, char *const *argv) {
 	int o = 0, longopt_idx = -1;
-
-	char *lc_numeric_old = strdup(setlocale(LC_NUMERIC, NULL));
-
-	// Enforce LC_NUMERIC locale "C" here to make sure dots are recognized
-	// instead of commas in atof().
-	setlocale(LC_NUMERIC, "C");
-
-	// Parse command line arguments. Range checking will be done later.
-
 	bool failed = false;
-	const char *deprecation_message attr_unused =
-	    "has been removed. If you encounter problems "
-	    "without this feature, please feel free to "
-	    "open a bug report.";
 	optind = 1;
 	while (-1 != (o = getopt_long(argc, argv, shortopts, longopts, &longopt_idx))) {
-		switch (o) {
-#define P_CASEBOOL(idx, option)                                                          \
-	case idx: opt->option = true; break
-#define P_CASELONG(idx, option)                                                          \
-	case idx:                                                                        \
-		if (!parse_long(optarg, &opt->option)) {                                 \
-			exit(1);                                                         \
-		}                                                                        \
-		break
-#define P_CASEINT(idx, option)                                                           \
-	case idx:                                                                        \
-		if (!parse_int(optarg, &opt->option)) {                                  \
-			exit(1);                                                         \
-		}                                                                        \
-		break
-
-		// clang-format off
-		// Short options
-		case 318:
-		case 'h':
-			// These options should cause us to exit early,
-			// so assert(false) here
-			assert(false);
-			break;
-		case 'b':
-		case 314:
-		case 320:
-			// These options are handled by get_early_config()
-			break;
-		P_CASEINT('D', fade_delta);
-		case 'I': opt->fade_in_step = normalize_d(atof(optarg)); break;
-		case 'O': opt->fade_out_step = normalize_d(atof(optarg)); break;
-		case 'c': shadow_enable = true; break;
-		case 'm':;
-			log_warn("--menu-opacity is deprecated, and will be removed."
-			         "Please use the wintype option `opacity` of `popup_menu`"
-			         "and `dropdown_menu` instead.");
-			double tmp;
-			tmp = normalize_d(atof(optarg));
-			winopt_mask[WINTYPE_DROPDOWN_MENU].opacity = true;
-			winopt_mask[WINTYPE_POPUP_MENU].opacity = true;
-			opt->wintype_option[WINTYPE_POPUP_MENU].opacity = tmp;
-			opt->wintype_option[WINTYPE_DROPDOWN_MENU].opacity = tmp;
-			break;
-		case 'f':
-			fading_enable = true;
-			break;
-		P_CASEINT('r', shadow_radius);
-		case 'o':
-			opt->shadow_opacity = atof(optarg);
-			break;
-		P_CASEINT('l', shadow_offset_x);
-		P_CASEINT('t', shadow_offset_y);
-		case 'i':
-			opt->inactive_opacity = normalize_d(atof(optarg));
-			break;
-		case 'e': opt->frame_opacity = atof(optarg); break;
-		case 'z':
-			log_warn("clear-shadow is removed, shadows are automatically "
-			         "cleared now. If you want to prevent shadow from been "
-			         "cleared under certain types of windows, you can use "
-			         "the \"full-shadow\" per window type option.");
-			break;
-		// Long options
-		case 256:
-			// --config
-			break;
-		case 332:;
-			// --shadow-color
-			struct color rgb;
-			rgb = hex_to_rgb(optarg);
-			opt->shadow_red = rgb.red;
-			opt->shadow_green = rgb.green;
-			opt->shadow_blue = rgb.blue;
-			break;
-		case 257:
-			// --shadow-red
-			opt->shadow_red = atof(optarg);
-			break;
-		case 258:
-			// --shadow-green
-			opt->shadow_green = atof(optarg);
-			break;
-		case 259:
-			// --shadow-blue
-			opt->shadow_blue = atof(optarg);
-			break;
-		P_CASEBOOL(260, inactive_opacity_override);
-		case 261:
-			// --inactive-dim
-			opt->inactive_dim = atof(optarg);
-			break;
-		P_CASEBOOL(262, mark_wmwin_focused);
-		case 263:
-			// --shadow-exclude
-			condlst_add(&opt->shadow_blacklist, optarg);
-			break;
-		P_CASEBOOL(264, mark_ovredir_focused);
-		P_CASEBOOL(265, no_fading_openclose);
-		P_CASEBOOL(266, shadow_ignore_shaped);
-		P_CASEBOOL(267, detect_rounded_corners);
-		P_CASEBOOL(268, detect_client_opacity);
-		case 269:
-			log_warn("--refresh-rate has been deprecated, please remove it "
-			         "from your command line options");
-			break;
-		case 270:
-			if (optarg) {
-				bool parsed_vsync = parse_vsync(optarg);
-				log_error("--vsync doesn't take argument anymore. \"%s\" "
-				          "should be changed to \"%s\"",
-				          optarg, parsed_vsync ? "true" : "false");
-				failed = true;
-			} else {
-				opt->vsync = true;
-			}
-			break;
-		P_CASEBOOL(271, crop_shadow_to_monitor);
-		case 272:
-			opt->crop_shadow_to_monitor = true;
-			log_warn("--xinerama-shadow-crop is deprecated. Use "
-			         "--crop-shadow-to-monitor instead.");
-			break;
-		case 274:
-			log_error("--sw-opti has been deprecated, please remove it from the "
-			         "command line options");
+		if (o == '?' || o == ':' || picom_options[o].arg.handler == NULL) {
+			usage(argv[0], 1);
 			failed = true;
-			break;
-		case 275:
-			// --vsync-aggressive
-			log_error("--vsync-aggressive has been removed, please remove it"
-			          " from the command line options");
+		} else if (!picom_options[o].arg.handler(
+		               &picom_options[o], &picom_options[o].arg, optarg, opt)) {
 			failed = true;
-			break;
-		P_CASEBOOL(276, use_ewmh_active_win);
-		case 277:
-			// --respect-prop-shadow
-			log_error("--respect-prop-shadow option has been deprecated, its "
-			         "functionality will always be enabled. Please remove it "
-			         "from the command line options");
-			failed = true;
-			break;
-		P_CASEBOOL(278, unredir_if_possible);
-		case 279:
-			// --focus-exclude
-			condlst_add(&opt->focus_blacklist, optarg);
-			break;
-		P_CASEBOOL(280, inactive_dim_fixed);
-		P_CASEBOOL(281, detect_transient);
-		P_CASEBOOL(282, detect_client_leader);
-		case 283:
-			// --blur_background
-			opt->blur_method = BLUR_METHOD_KERNEL;
-			break;
-		P_CASEBOOL(284, blur_background_frame);
-		P_CASEBOOL(285, blur_background_fixed);
-		P_CASEBOOL(286, dbus);
-		case 287:
-			log_warn("Please use --log-file instead of --logpath");
-			// fallthrough
-		case 322:
-			// --logpath, --log-file
-			free(opt->logpath);
-			opt->logpath = strdup(optarg);
-			break;
-		case 288:
-			// --invert-color-include
-			condlst_add(&opt->invert_color_list, optarg);
-			break;
-		case 289:
-			// --opengl
-			opt->backend = BKEND_GLX;
-			break;
-		case 290:
-			// --backend
-			opt->backend = parse_backend(optarg);
-			if (opt->backend >= NUM_BKEND) {
-				exit(1);
-			}
-			break;
-		P_CASEBOOL(291, glx_no_stencil);
-		P_CASEINT(293, benchmark);
-		case 294:
-			// --benchmark-wid
-			opt->benchmark_wid = (xcb_window_t)strtol(optarg, NULL, 0);
-			break;
-		case 296:
-			// --blur-background-exclude
-			condlst_add(&opt->blur_background_blacklist, optarg);
-			break;
-		case 297:
-			// --active-opacity
-			opt->active_opacity = normalize_d(atof(optarg));
-			break;
-		P_CASEBOOL(298, glx_no_rebind_pixmap);
-		case 299: {
-			// --glx-swap-method
-			char *endptr;
-			long tmpval = strtol(optarg, &endptr, 10);
-			bool should_remove = true;
-			if (*endptr || !(*optarg)) {
-				// optarg is not a number, or an empty string
-				tmpval = -1;
-			}
-			if (strcmp(optarg, "undefined") != 0 && tmpval != 0) {
-				// If not undefined, we will use damage and buffer-age to
-				// limit the rendering area.
-				should_remove = false;
-			}
-			log_error("--glx-swap-method has been removed, your setting "
-			         "\"%s\" should be %s.",
-			         optarg,
-			         !should_remove ? "replaced by `--use-damage`" :
-			                         "removed");
-			failed = true;
-			break;
 		}
-		case 300:
-			// --fade-exclude
-			condlst_add(&opt->fade_blacklist, optarg);
-			break;
-		case 301:
-			// --blur-kern
-			opt->blur_kerns = parse_blur_kern_lst(optarg, &conv_kern_hasneg,
-			                                      &opt->blur_kernel_count);
-			if (!opt->blur_kerns) {
-				exit(1);
-			}
-			break;
-		P_CASEINT(302, resize_damage);
-		case 303:
-			// --glx-use-gpushader4
-			log_error("--glx-use-gpushader4 has been removed."
-			         " Please remove it from command line options.");
-			failed = true;
-			break;
-		case 304:
-			// --opacity-rule
-			if (!c2_parse_with_prefix(&opt->opacity_rules, optarg, parse_numeric_prefix, NULL, (int[]){0, 100})) {
-				exit(1);
-			}
-			break;
-		case 305:
-			// --shadow-exclude-reg
-			log_error("--shadow-exclude-reg is deprecated. You are likely "
-			         "better off using --clip-shadow-above anyway");
-			failed = true;
-			break;
-		case 306:
-			// --paint-exclude
-			condlst_add(&opt->paint_blacklist, optarg);
-			break;
-		case 308:
-			// --unredir-if-possible-exclude
-			condlst_add(&opt->unredir_if_possible_blacklist, optarg);
-			break;
-		P_CASELONG(309, unredir_if_possible_delay);
-		case 310:
-			// --write-pid-path
-			free(opt->write_pid_path);
-			opt->write_pid_path = strdup(optarg);
-			if (*opt->write_pid_path != '/') {
-				log_warn("--write-pid-path is not an absolute path");
-			}
-			break;
-		P_CASEBOOL(311, vsync_use_glfinish);
-		P_CASEBOOL(313, xrender_sync_fence);
-		P_CASEBOOL(315, no_fading_destroyed_argb);
-		P_CASEBOOL(316, force_win_blend);
-		case 317:
-			opt->glx_fshader_win_str = strdup(optarg);
-			break;
-		case 336: {
-			// --window-shader-fg
-			scoped_charp cwd = getcwd(NULL, 0);
-			opt->window_shader_fg =
-			    locate_auxiliary_file("shaders", optarg, cwd);
-			if (!opt->window_shader_fg) {
-				exit(1);
-			}
-			break;
-		}
-		case 337: {
-			// --window-shader-fg-rule
-			scoped_charp cwd = getcwd(NULL, 0);
-			if (!c2_parse_with_prefix(&opt->window_shader_fg_rules, optarg, parse_window_shader_prefix, free, cwd)) {
-				exit(1);
-			}
-			break;
-		}
-		case 338: {
-			// --transparent-clipping-exclude
-			condlst_add(&opt->transparent_clipping_blacklist, optarg);
-			break;
-		}
-		case 321: {
-			enum log_level tmp_level = string_to_log_level(optarg);
-			if (tmp_level == LOG_LEVEL_INVALID) {
-				log_warn("Invalid log level, defaults to WARN");
-			} else {
-				log_set_level_tls(tmp_level);
-			}
-			break;
-		}
-		P_CASEBOOL(319, no_x_selection);
-		P_CASEBOOL(323, use_damage);
-		case 324: opt->use_damage = false; break;
-		case 325: opt->vsync = false; break;
-		case 326:
-			opt->max_brightness = atof(optarg);
-			break;
-		P_CASEBOOL(327, transparent_clipping);
-		case 328: {
-			// --blur-method
-			enum blur_method method = parse_blur_method(optarg);
-			if (method >= BLUR_METHOD_INVALID) {
-				log_warn("Invalid blur method %s, ignoring.", optarg);
-			} else {
-				opt->blur_method = method;
-			}
-			break;
-		}
-		case 329:
-			// --blur-size
-			opt->blur_radius = atoi(optarg);
-			break;
-		case 330:
-			// --blur-deviation
-			opt->blur_deviation = atof(optarg);
-			break;
-		case 331:
-			// --blur-strength
-			opt->blur_strength = atoi(optarg);
-			break;
-		case 333:
-			// --corner-radius
-			opt->corner_radius = atoi(optarg);
-			break;
-		case 334:
-			// --rounded-corners-exclude
-			condlst_add(&opt->rounded_corners_blacklist, optarg);
-			break;
-		case 340:
-			// --corner-radius-rules
-			if (!c2_parse_with_prefix(&opt->corner_radius_rules, optarg, parse_numeric_prefix, NULL, (int[]){0, INT_MAX})) {
-				exit(1);
-			}
-			break;
-		case 335:
-			// --clip-shadow-above
-			condlst_add(&opt->shadow_clip_list, optarg);
-			break;
-		case 339:
-			// --dithered-present
-			opt->dithered_present = true;
-			break;
-		P_CASEBOOL(341, no_frame_pacing);
-		P_CASEBOOL(733, legacy_backends);
-		P_CASEBOOL(800, monitor_repaint);
-		case 801:
-			opt->print_diagnostics = true;
-			break;
-		P_CASEBOOL(802, debug_mode);
-		P_CASEBOOL(803, no_ewmh_fullscreen);
-		P_CASEBOOL(804, use_realtime_scheduling);
-		default: usage(argv[0], 1); break;
-#undef P_CASEBOOL
-		}
-		// clang-format on
 
 		if (failed) {
 			// Parsing this option has failed, break the loop
@@ -756,16 +743,27 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 		}
 	}
 
-	// Restore LC_NUMERIC
-	setlocale(LC_NUMERIC, lc_numeric_old);
-	free(lc_numeric_old);
-
 	if (failed) {
 		return false;
 	}
 
+	log_set_level_tls(opt->log_level);
 	if (opt->monitor_repaint && opt->backend != BKEND_XRENDER && opt->legacy_backends) {
 		log_warn("--monitor-repaint has no effect when backend is not xrender");
+	}
+
+	if (opt->window_shader_fg) {
+		scoped_charp cwd = getcwd(NULL, 0);
+		scoped_charp tmp = opt->window_shader_fg;
+		opt->window_shader_fg = locate_auxiliary_file("shaders", tmp, cwd);
+		if (!opt->window_shader_fg) {
+			log_error("Couldn't find the specified window shader file \"%s\"", tmp);
+			return false;
+		}
+	}
+
+	if (opt->write_pid_path && *opt->write_pid_path != '/') {
+		log_warn("--write-pid-path is not an absolute path");
 	}
 
 	if (opt->backend == BKEND_EGL) {
@@ -814,15 +812,6 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 	}
 
 	// Range checking and option assignments
-	opt->fade_delta = max2(opt->fade_delta, 1);
-	opt->shadow_radius = max2(opt->shadow_radius, 0);
-	opt->shadow_red = normalize_d(opt->shadow_red);
-	opt->shadow_green = normalize_d(opt->shadow_green);
-	opt->shadow_blue = normalize_d(opt->shadow_blue);
-	opt->inactive_dim = normalize_d(opt->inactive_dim);
-	opt->frame_opacity = normalize_d(opt->frame_opacity);
-	opt->shadow_opacity = normalize_d(opt->shadow_opacity);
-	opt->max_brightness = normalize_d(opt->max_brightness);
 	if (opt->max_brightness < 1.0) {
 		if (opt->backend == BKEND_XRENDER || opt->legacy_backends) {
 			log_warn("--max-brightness is not supported by the %s backend. "
@@ -842,10 +831,7 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 	}
 
 	// Apply default wintype options that are dependent on global options
-	set_default_winopts(opt, winopt_mask, shadow_enable, fading_enable,
-	                    opt->blur_method != BLUR_METHOD_NONE);
-
-	// Other variables determined by options
+	set_default_winopts(opt);
 
 	// Determine whether we track window grouping
 	if (opt->detect_transient || opt->detect_client_leader) {
@@ -855,8 +841,7 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 	// Fill default blur kernel
 	if (opt->blur_method == BLUR_METHOD_KERNEL &&
 	    (!opt->blur_kerns || !opt->blur_kerns[0])) {
-		opt->blur_kerns = parse_blur_kern_lst("3x3box", &conv_kern_hasneg,
-		                                      &opt->blur_kernel_count);
+		opt->blur_kerns = parse_blur_kern_lst("3x3box", &opt->blur_kernel_count);
 		CHECK(opt->blur_kerns);
 		CHECK(opt->blur_kernel_count);
 	}
@@ -883,9 +868,19 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 		log_warn("Negative --resize-damage will not work correctly.");
 	}
 
-	if (opt->backend == BKEND_XRENDER && conv_kern_hasneg) {
-		log_warn("A convolution kernel with negative values may not work "
-		         "properly under X Render backend.");
+	if (opt->backend == BKEND_XRENDER) {
+		for (int i = 0; i < opt->blur_kernel_count; i++) {
+			auto kernel = opt->blur_kerns[i];
+			for (int j = 0; j < kernel->h * kernel->w; j++) {
+				if (kernel->data[j] < 0) {
+					log_warn("A convolution kernel with negative "
+					         "values may not work properly under X "
+					         "Render backend.");
+					goto check_end;
+				}
+			}
+		}
+	check_end:;
 	}
 
 	return true;

--- a/src/options.h
+++ b/src/options.h
@@ -30,9 +30,7 @@ bool get_early_config(int argc, char *const *argv, char **config_file, bool *all
  * Returns:
  *   Whether configuration are processed successfully.
  */
-bool must_use get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
-                      bool fading_enable, bool conv_kern_hasneg,
-                      win_option_mask_t *winopt_mask);
+bool must_use get_cfg(options_t *opt, int argc, char *const *argv);
 void options_postprocess_c2_lists(struct c2_state *state, struct x_connection *c,
                                   struct options *option);
 void options_destroy(struct options *options);

--- a/src/picom.c
+++ b/src/picom.c
@@ -1492,7 +1492,7 @@ static bool redirect_start(session_t *ps) {
 		pixman_region32_init(&ps->damage_ring.damages[i]);
 	}
 
-	ps->frame_pacing = !ps->o.no_frame_pacing && ps->o.vsync;
+	ps->frame_pacing = ps->o.frame_pacing && ps->o.vsync;
 	if ((ps->o.legacy_backends || ps->o.benchmark || !ps->backend_data->ops->last_render_time) &&
 	    ps->frame_pacing) {
 		// Disable frame pacing if we are using a legacy backend or if we are in
@@ -2208,18 +2208,15 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	}
 
 	// Parse configuration file
-	win_option_mask_t winopt_mask[NUM_WINTYPES] = {{0}};
-	bool shadow_enabled = false, fading_enable = false, hasneg = false;
 	char *config_file_to_free = NULL;
-	config_file = config_file_to_free = parse_config(
-	    &ps->o, config_file, &shadow_enabled, &fading_enable, &hasneg, winopt_mask);
+	config_file = config_file_to_free = parse_config(&ps->o, config_file);
 
 	if (IS_ERR(config_file_to_free)) {
 		return NULL;
 	}
 
 	// Parse all of the rest command line options
-	if (!get_cfg(&ps->o, argc, argv, shadow_enabled, fading_enable, hasneg, winopt_mask)) {
+	if (!get_cfg(&ps->o, argc, argv)) {
 		log_fatal("Failed to get configuration, usually mean you have specified "
 		          "invalid options.");
 		return NULL;


### PR DESCRIPTION
The main objective is to remove the need to worry about option value assignment. Because of the way getopt works, we need to assign a number to each option, and later match the return value of getopt in a big switch. We have to make sure to not assign the same number to two options, and we have to carefully make sure the same number is used in two different places (once in the options table, once in the switch). And that is just annoying.

With this commit everything is in one place, and the compiler will yell at us if we assigned duplicated numbers.

Maybe this can also be a stepping stone for unifying command line options parsing and config file parsing.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
