### PR TITLE
backend: decompose mask into source and target mask

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -62,7 +62,7 @@ bool backend_execute(struct backend_base *backend, image_handle target, unsigned
 	for (auto cmd = &cmds[0]; succeeded && cmd != &cmds[ncmds]; cmd++) {
 		switch (cmd->op) {
 		case BACKEND_COMMAND_BLIT:
-			if (!pixman_region32_not_empty(&cmd->blit.mask->region)) {
+			if (!pixman_region32_not_empty(cmd->blit.target_mask)) {
 				continue;
 			}
 			succeeded =
@@ -77,7 +77,7 @@ bool backend_execute(struct backend_base *backend, image_handle target, unsigned
 			                                    cmd->copy_area.region);
 			break;
 		case BACKEND_COMMAND_BLUR:
-			if (!pixman_region32_not_empty(&cmd->blur.mask->region)) {
+			if (!pixman_region32_not_empty(cmd->blur.target_mask)) {
 				continue;
 			}
 			succeeded =
@@ -110,11 +110,11 @@ void log_backend_command_(enum log_level level, const char *func,
 	case BACKEND_COMMAND_BLIT:
 		log_printf(tls_logger, level, func, "blit %s%s",
 		           render_command_source_name(cmd->source),
-		           cmd->need_mask_image ? ", with mask image" : "");
+		           cmd->blit.source_mask != NULL ? ", with mask image" : "");
 		log_printf(tls_logger, level, func, "origin: %d,%d", cmd->origin.x,
 		           cmd->origin.y);
 		log_printf(tls_logger, level, func, "mask region:");
-		log_region_(level, func, &cmd->blit.mask->region);
+		log_region_(level, func, cmd->blit.target_mask);
 		log_printf(tls_logger, level, func, "opaque region:");
 		log_region_(level, func, &cmd->opaque_region);
 		break;
@@ -128,11 +128,11 @@ void log_backend_command_(enum log_level level, const char *func,
 		break;
 	case BACKEND_COMMAND_BLUR:
 		log_printf(tls_logger, level, func, "blur%s",
-		           cmd->need_mask_image ? ", with mask image" : "");
+		           cmd->blur.source_mask != NULL ? ", with mask image" : "");
 		log_printf(tls_logger, level, func, "origin: %d,%d", cmd->origin.x,
 		           cmd->origin.y);
 		log_printf(tls_logger, level, func, "mask region:");
-		log_region_(level, func, &cmd->blur.mask->region);
+		log_region_(level, func, cmd->blur.target_mask);
 		break;
 	case BACKEND_COMMAND_INVALID:
 		log_printf(tls_logger, level, func, "invalid");

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -75,14 +75,14 @@ bool dummy_blit(struct backend_base *base, ivec2 origin attr_unused, image_handl
                 struct backend_blit_args *args) {
 	dummy_check_image(base, target);
 	dummy_check_image(base, args->source_image);
-	if (args->mask->image) {
-		auto mask = (struct dummy_image *)args->mask->image;
+	if (args->source_mask) {
+		auto mask = (struct dummy_image *)args->source_mask->image;
 		if (mask->format != BACKEND_IMAGE_FORMAT_MASK) {
 			log_error("Invalid mask image format");
 			assert(false);
 			return false;
 		}
-		dummy_check_image(base, args->mask->image);
+		dummy_check_image(base, args->source_mask->image);
 	}
 	return true;
 }
@@ -91,14 +91,14 @@ bool dummy_blur(struct backend_base *base, ivec2 origin attr_unused, image_handl
                 struct backend_blur_args *args) {
 	dummy_check_image(base, target);
 	dummy_check_image(base, args->source_image);
-	if (args->mask->image) {
-		auto mask = (struct dummy_image *)args->mask->image;
+	if (args->source_mask) {
+		auto mask = (struct dummy_image *)args->source_mask->image;
 		if (mask->format != BACKEND_IMAGE_FORMAT_MASK) {
 			log_error("Invalid mask image format");
 			assert(false);
 			return false;
 		}
-		dummy_check_image(base, args->mask->image);
+		dummy_check_image(base, args->source_mask->image);
 	}
 	return true;
 }

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -126,14 +126,13 @@ void gl_prepare(backend_t *base, const region_t *reg);
 /// @param[in]  rects       mask rectangles, in mask coordinates
 /// @param[out] coord       OpenGL vertex coordinates, suitable for creating VAO/VBO
 /// @param[out] indices     OpenGL vertex indices, suitable for creating VAO/VBO
-void gl_mask_rects_to_coords(ivec2 origin, ivec2 mask_origin, int nrects,
-                             const rect_t *rects, GLint *coord, GLuint *indices);
+void gl_mask_rects_to_coords(ivec2 origin, int nrects, const rect_t *rects, GLint *coord,
+                             GLuint *indices);
 /// Like `gl_mask_rects_to_coords`, but with `origin` and `mask_origin` set to 0. i.e. all
 /// coordinates are in the same space.
 static inline void gl_mask_rects_to_coords_simple(int nrects, const rect_t *rects,
                                                   GLint *coord, GLuint *indices) {
-	return gl_mask_rects_to_coords((ivec2){0, 0}, (ivec2){0, 0}, nrects, rects, coord,
-	                               indices);
+	return gl_mask_rects_to_coords((ivec2){0, 0}, nrects, rects, coord, indices);
 }
 
 GLuint gl_create_shader(GLenum shader_type, const char *shader_str);

--- a/src/region.h
+++ b/src/region.h
@@ -154,18 +154,18 @@ static inline void region_intersect(region_t *region, ivec2 origin, const region
 	pixman_region32_translate(region, origin.x, origin.y);
 }
 
-/// Calculate the symmetric difference of `region1`, and `region2` placed at
-/// `origin2`, and union the result into `result`.
+/// Calculate the symmetric difference of `region1`, and `region2`, and union the result
+/// into `result`. The two input regions has to be in the same coordinate space.
 ///
 /// @param scratch a region to store temporary results
-static inline void region_symmetric_difference(region_t *result, region_t *scratch,
-                                               ivec2 origin1, const region_t *region1,
-                                               ivec2 origin2, const region_t *region2) {
+static inline void
+region_symmetric_difference_local(region_t *result, region_t *scratch,
+                                  const region_t *region1, const region_t *region2) {
 	pixman_region32_copy(scratch, region1);
-	region_subtract(scratch, ivec2_sub(origin2, origin1), region2);
-	region_union(result, origin1, scratch);
+	pixman_region32_subtract(scratch, scratch, region2);
+	pixman_region32_union(result, result, scratch);
 
 	pixman_region32_copy(scratch, region2);
-	region_subtract(scratch, ivec2_sub(origin1, origin2), region1);
-	region_union(result, origin2, scratch);
+	pixman_region32_subtract(scratch, scratch, region1);
+	pixman_region32_union(result, result, scratch);
 }

--- a/src/renderer/command_builder.c
+++ b/src/renderer/command_builder.c
@@ -32,56 +32,51 @@ commands_for_window_body(struct layer *layer, struct backend_command *cmd,
 		border_width = min3(w->frame_extents.left, w->frame_extents.right,
 		                    w->frame_extents.bottom);
 	}
-	cmd->op = BACKEND_COMMAND_BLIT;
-	cmd->source = BACKEND_COMMAND_SOURCE_WINDOW;
-	cmd->origin = layer->origin;
-	cmd->blit = (struct backend_blit_args){
-	    .border_width = border_width,
-	    .mask = &cmd->mask,
-	    .corner_radius = w->corner_radius,
-	    .opacity = layer->opacity,
-	    .dim = dim,
-	    .effective_size = {.width = w->widthb, .height = w->heightb},
-	    .shader = w->fg_shader ? w->fg_shader->backend_shader : NULL,
-	    .color_inverted = w->invert_color,
-	    .max_brightness = max_brightness};
-	cmd->mask.inverted = false;
-	cmd->mask.corner_radius = 0;
-	cmd->mask.origin = (ivec2){};
-	pixman_region32_copy(&cmd->mask.region, &w->bounding_shape);
+	ivec2 raw_size = {.width = w->widthb, .height = w->heightb};
+	pixman_region32_copy(&cmd->target_mask, &w->bounding_shape);
+	pixman_region32_translate(&cmd->target_mask, layer->origin.x, layer->origin.y);
 	if (w->frame_opacity < 1) {
-		pixman_region32_subtract(&cmd->mask.region, &cmd->mask.region, frame_region);
+		pixman_region32_subtract(&cmd->target_mask, &cmd->target_mask, frame_region);
 	}
-	cmd->need_mask_image = false;
 	pixman_region32_init(&cmd->opaque_region);
 	if ((mode == WMODE_SOLID || mode == WMODE_FRAME_TRANS) && layer->opacity == 1.0) {
-		pixman_region32_copy(&cmd->opaque_region, &cmd->mask.region);
+		pixman_region32_copy(&cmd->opaque_region, &cmd->target_mask);
 		if (mode == WMODE_FRAME_TRANS) {
 			pixman_region32_subtract(&cmd->opaque_region, &cmd->opaque_region,
 			                         frame_region);
 		}
 	}
 	if (w->corner_radius > 0) {
-		win_region_remove_corners(w, &cmd->opaque_region);
+		win_region_remove_corners(w, layer->origin, &cmd->opaque_region);
 	}
-	pixman_region32_translate(&cmd->opaque_region, layer->origin.x, layer->origin.y);
+	cmd->op = BACKEND_COMMAND_BLIT;
+	cmd->source = BACKEND_COMMAND_SOURCE_WINDOW;
+	cmd->origin = layer->origin;
+	cmd->blit = (struct backend_blit_args){
+	    .border_width = border_width,
+	    .target_mask = &cmd->target_mask,
+	    .corner_radius = w->corner_radius,
+	    .opacity = layer->opacity,
+	    .dim = dim,
+	    .effective_size = raw_size,
+	    .shader = w->fg_shader ? w->fg_shader->backend_shader : NULL,
+	    .color_inverted = w->invert_color,
+	    .source_mask = NULL,
+	    .max_brightness = max_brightness};
+
 	if (w->frame_opacity == 1 || w->frame_opacity == 0) {
 		return 1;
 	}
-
 	cmd -= 1;
+
+	pixman_region32_copy(&cmd->target_mask, frame_region);
+	pixman_region32_init(&cmd->opaque_region);
 	cmd->op = BACKEND_COMMAND_BLIT;
 	cmd->origin = layer->origin;
 	cmd->source = BACKEND_COMMAND_SOURCE_WINDOW;
-	cmd->need_mask_image = false;
 	cmd->blit = cmd[1].blit;
-	cmd->blit.mask = &cmd->mask;
+	cmd->blit.target_mask = &cmd->target_mask;
 	cmd->blit.opacity *= w->frame_opacity;
-	cmd->mask.origin = (ivec2){};
-	cmd->mask.inverted = false;
-	cmd->mask.corner_radius = 0;
-	pixman_region32_copy(&cmd->mask.region, frame_region);
-	pixman_region32_init(&cmd->opaque_region);
 	return 2;
 }
 
@@ -99,15 +94,13 @@ command_for_shadow(struct layer *layer, struct backend_command *cmd,
 	cmd->op = BACKEND_COMMAND_BLIT;
 	cmd->origin = layer->shadow_origin;
 	cmd->source = BACKEND_COMMAND_SOURCE_SHADOW;
-	// Initialize mask region in the current window's coordinates, we
-	// will later move it to the correct coordinates
-	pixman_region32_clear(&cmd->mask.region);
-	pixman_region32_union_rect(
-	    &cmd->mask.region, &cmd->mask.region, layer->shadow_origin.x - layer->origin.x,
-	    layer->shadow_origin.y - layer->origin.y, (unsigned)layer->shadow_size.width,
-	    (unsigned)layer->shadow_size.height);
+	pixman_region32_clear(&cmd->target_mask);
+	pixman_region32_union_rect(&cmd->target_mask, &cmd->target_mask,
+	                           layer->shadow_origin.x, layer->shadow_origin.y,
+	                           (unsigned)layer->shadow_size.width,
+	                           (unsigned)layer->shadow_size.height);
 	log_trace("Calculate shadow for %#010x (%s)", w->base.id, w->name);
-	log_region(TRACE, &cmd->mask.region);
+	log_region(TRACE, &cmd->target_mask);
 	if (!wintype_options[w->window_type].full_shadow) {
 		// We need to not draw under the window
 		// From this command up, until the next WINDOW_START
@@ -115,50 +108,38 @@ command_for_shadow(struct layer *layer, struct backend_command *cmd,
 		for (auto j = cmd + 1; j != end; j++) {
 			assert(j->op == BACKEND_COMMAND_BLIT);
 			assert(j->source == BACKEND_COMMAND_SOURCE_WINDOW);
-			assert(j->mask.origin.x == 0 && j->mask.origin.y == 0);
 			if (j->blit.corner_radius == 0) {
 				pixman_region32_subtract(
-				    &cmd->mask.region, &cmd->mask.region, &j->mask.region);
+				    &cmd->target_mask, &cmd->target_mask, &j->target_mask);
 			} else {
 				region_t mask_without_corners;
 				pixman_region32_init(&mask_without_corners);
-				pixman_region32_copy(&mask_without_corners, &j->mask.region);
-				win_region_remove_corners(layer->win, &mask_without_corners);
-				pixman_region32_subtract(&cmd->mask.region, &cmd->mask.region,
+				pixman_region32_copy(&mask_without_corners, &j->target_mask);
+				win_region_remove_corners(layer->win, j->origin,
+				                          &mask_without_corners);
+				pixman_region32_subtract(&cmd->target_mask, &cmd->target_mask,
 				                         &mask_without_corners);
 				pixman_region32_fini(&mask_without_corners);
 			}
 		}
 	}
-	log_region(TRACE, &cmd->mask.region);
-	// Move mask region to screen coordinates for shadow exclusion
-	// calculation
-	pixman_region32_translate(&cmd->mask.region, layer->origin.x, layer->origin.y);
+	log_region(TRACE, &cmd->target_mask);
 	if (monitors && w->randr_monitor >= 0 && w->randr_monitor < monitors->count) {
-		pixman_region32_intersect(&cmd->mask.region, &cmd->mask.region,
+		pixman_region32_intersect(&cmd->target_mask, &cmd->target_mask,
 		                          &monitors->regions[w->randr_monitor]);
 	}
-	log_region(TRACE, &cmd->mask.region);
-	// Finally move mask region to the correct coordinates
-	pixman_region32_translate(&cmd->mask.region, -layer->shadow_origin.x,
-	                          -layer->shadow_origin.y);
-	cmd->mask.corner_radius = w->corner_radius;
-	cmd->mask.inverted = true;
-	cmd->mask.origin = (ivec2){};
-	cmd->need_mask_image = w->corner_radius > 0;
-	if (cmd->need_mask_image) {
-		// If we use the window's mask image, we need to align the
-		// mask region's origin with it.
-		cmd->mask.origin = ivec2_sub(layer->origin, layer->shadow_origin);
-		pixman_region32_translate(&cmd->mask.region, -cmd->mask.origin.x,
-		                          -cmd->mask.origin.y);
+	log_region(TRACE, &cmd->target_mask);
+	if (w->corner_radius > 0) {
+		cmd->source_mask.corner_radius = w->corner_radius;
+		cmd->source_mask.inverted = true;
+		cmd->source_mask.origin = ivec2_sub(layer->origin, layer->shadow_origin);
 	}
-	log_region(TRACE, &cmd->mask.region);
 	cmd->blit = (struct backend_blit_args){
 	    .opacity = layer->shadow_opacity,
 	    .max_brightness = 1,
-	    .mask = &cmd->mask,
+	    .source_mask = w->corner_radius > 0 ? &cmd->source_mask : NULL,
 	    .effective_size = layer->shadow_size,
+	    .target_mask = &cmd->target_mask,
 	};
 	pixman_region32_init(&cmd->opaque_region);
 	return 1;
@@ -172,21 +153,27 @@ command_for_blur(struct layer *layer, struct backend_command *cmd,
 	if (!w->blur_background || layer->blur_opacity == 0) {
 		return 0;
 	}
-	cmd->op = BACKEND_COMMAND_BLUR;
-	cmd->origin = (ivec2){};
-	cmd->blur.opacity = layer->blur_opacity;
-	cmd->blur.mask = &cmd->mask;
-	cmd->mask.origin = (ivec2){.x = layer->origin.x, .y = layer->origin.y};
-	cmd->need_mask_image = w->corner_radius > 0;
-	cmd->mask.corner_radius = w->corner_radius;
-	cmd->mask.inverted = false;
 	if (force_blend || mode == WMODE_TRANS || layer->opacity < 1.0) {
-		pixman_region32_copy(&cmd->mask.region, &w->bounding_shape);
+		pixman_region32_copy(&cmd->target_mask, &w->bounding_shape);
+		pixman_region32_translate(&cmd->target_mask, layer->origin.x,
+		                          layer->origin.y);
 	} else if (blur_frame && mode == WMODE_FRAME_TRANS) {
-		pixman_region32_copy(&cmd->mask.region, frame_region);
+		pixman_region32_copy(&cmd->target_mask, frame_region);
 	} else {
 		return 0;
 	}
+	cmd->op = BACKEND_COMMAND_BLUR;
+	cmd->origin = (ivec2){};
+	if (w->corner_radius > 0) {
+		cmd->source_mask.origin = (ivec2){.x = layer->origin.x, .y = layer->origin.y};
+		cmd->source_mask.corner_radius = w->corner_radius;
+		cmd->source_mask.inverted = false;
+	}
+	cmd->blur = (struct backend_blur_args){
+	    .opacity = layer->blur_opacity,
+	    .target_mask = &cmd->target_mask,
+	    .source_mask = w->corner_radius > 0 ? &cmd->source_mask : NULL,
+	};
 	return 1;
 }
 
@@ -227,8 +214,8 @@ command_builder_apply_transparent_clipping(struct layout *layout, region_t *scra
 		if (i->op == BACKEND_COMMAND_BLUR ||
 		    (i->op == BACKEND_COMMAND_BLIT &&
 		     i->source != BACKEND_COMMAND_SOURCE_BACKGROUND)) {
-			auto scratch_origin = ivec2_sub(ivec2_neg(i->origin), i->mask.origin);
-			region_subtract(&i->mask.region, scratch_origin, scratch_region);
+			pixman_region32_subtract(&i->target_mask, &i->target_mask,
+			                         scratch_region);
 		}
 		if (i->op == BACKEND_COMMAND_BLIT &&
 		    i->source != BACKEND_COMMAND_SOURCE_BACKGROUND) {
@@ -254,17 +241,17 @@ command_builder_apply_shadow_clipping(struct layout *layout, region_t *scratch_r
 			clip_shadow_above = layer->win->clip_shadow_above;
 		}
 
-		auto mask_origin = ivec2_add(i->mask.origin, i->origin);
 		if (i->op == BACKEND_COMMAND_BLUR) {
-			region_subtract(scratch_region, mask_origin, &i->mask.region);
+			pixman_region32_subtract(scratch_region, scratch_region,
+			                         &i->target_mask);
 		} else if (i->op == BACKEND_COMMAND_BLIT) {
 			if (i->source == BACKEND_COMMAND_SOURCE_SHADOW) {
-				mask_origin.x = -mask_origin.x;
-				mask_origin.y = -mask_origin.y;
-				region_subtract(&i->mask.region, mask_origin, scratch_region);
+				pixman_region32_subtract(&i->target_mask, &i->target_mask,
+				                         scratch_region);
 			} else if (i->source == BACKEND_COMMAND_SOURCE_WINDOW &&
 			           clip_shadow_above) {
-				region_union(scratch_region, mask_origin, &i->mask.region);
+				pixman_region32_union(scratch_region, scratch_region,
+				                      &i->target_mask);
 			}
 		}
 	}
@@ -294,7 +281,7 @@ command_builder_command_list_new(struct command_builder *cb, unsigned ncmds) {
 	}
 	if (capacity < ncmds || capacity / 2 > ncmds) {
 		for (unsigned i = ncmds; i < capacity; i++) {
-			pixman_region32_fini(&list->commands[i].mask.region);
+			pixman_region32_fini(&list->commands[i].target_mask);
 		}
 
 		struct command_list *new_list = realloc(list, size);
@@ -306,7 +293,7 @@ command_builder_command_list_new(struct command_builder *cb, unsigned ncmds) {
 
 		for (unsigned i = capacity; i < ncmds; i++) {
 			list->commands[i].op = BACKEND_COMMAND_INVALID;
-			pixman_region32_init(&list->commands[i].mask.region);
+			pixman_region32_init(&list->commands[i].target_mask);
 		}
 	}
 	return list;
@@ -339,7 +326,7 @@ void command_builder_free(struct command_builder *cb) {
 	list_foreach_safe(struct command_list, i, &cb->free_command_lists, free_list) {
 		list_remove(&i->free_list);
 		for (unsigned j = 0; j < i->capacity; j++) {
-			pixman_region32_fini(&i->commands[j].mask.region);
+			pixman_region32_fini(&i->commands[j].target_mask);
 		}
 		free(i);
 	}
@@ -381,8 +368,9 @@ void command_builder_build(struct command_builder *cb, struct layout *layout, bo
 	auto cmd = &layout->commands[ncmds - 1];
 	for (int i = to_int_checked(layout->len) - 1; i >= 0; i--) {
 		auto layer = &layout->layers[i];
-		auto frame_region = win_get_region_frame_local_by_val(layer->win);
 		auto last = cmd;
+		auto frame_region = win_get_region_frame_local_by_val(layer->win);
+		pixman_region32_translate(&frame_region, layer->origin.x, layer->origin.y);
 
 		// Add window body
 		cmd -= commands_for_window_body(layer, cmd, &frame_region, inactive_dim_fixed,
@@ -403,9 +391,9 @@ void command_builder_build(struct command_builder *cb, struct layout *layout, bo
 	cmd->source = BACKEND_COMMAND_SOURCE_BACKGROUND;
 	cmd->origin = (ivec2){};
 	pixman_region32_reset(
-	    &cmd->mask.region,
+	    &cmd->target_mask,
 	    (rect_t[]){{.x1 = 0, .y1 = 0, .x2 = layout->size.width, .y2 = layout->size.height}});
-	cmd->copy_area.region = &cmd->mask.region;
+	cmd->copy_area.region = &cmd->target_mask;
 	assert(cmd == list->commands);
 
 	layout->first_layer_start = 1;

--- a/src/renderer/damage.c
+++ b/src/renderer/damage.c
@@ -323,8 +323,9 @@ void commands_cull_with_damage(struct layout *layout, const region_t *damage,
 		} else {
 			mask_origin = cmd->origin;
 		}
+		region_t tmp_region = culled_mask[i].region;
 		culled_mask[i] = cmd->mask;
-		pixman_region32_init(&culled_mask[i].region);
+		culled_mask[i].region = tmp_region;
 		pixman_region32_copy(&culled_mask[i].region, &cmd->mask.region);
 		region_intersect(&culled_mask[i].region, ivec2_neg(mask_origin),
 		                 &scratch_region);
@@ -358,16 +359,9 @@ void commands_uncull(struct layout *layout) {
 	for (auto i = layout->commands;
 	     i != &layout->commands[layout->number_of_commands]; i++) {
 		switch (i->op) {
-		case BACKEND_COMMAND_BLIT:
-			pixman_region32_fini(&i->blit.mask->region);
-			i->blit.mask = &i->mask;
-			break;
-		case BACKEND_COMMAND_BLUR:
-			pixman_region32_fini(&i->blur.mask->region);
-			i->blur.mask = &i->mask;
-			break;
+		case BACKEND_COMMAND_BLIT: i->blit.mask = &i->mask; break;
+		case BACKEND_COMMAND_BLUR: i->blur.mask = &i->mask; break;
 		case BACKEND_COMMAND_COPY_AREA:
-			pixman_region32_fini((region_t *)i->copy_area.region);
 			i->copy_area.region = &i->mask.region;
 			break;
 		case BACKEND_COMMAND_INVALID: assert(false);

--- a/src/renderer/damage.c
+++ b/src/renderer/damage.c
@@ -57,7 +57,7 @@ layer_compare(const struct layer *past_layer, const struct backend_command *past
 static inline void region_union_render_layer(region_t *region, const struct layer *layer,
                                              const struct backend_command *cmds) {
 	for (auto i = cmds; i < &cmds[layer->number_of_commands]; i++) {
-		region_union(region, ivec2_add(i->origin, i->mask.origin), &i->mask.region);
+		pixman_region32_union(region, region, &i->target_mask);
 	}
 }
 
@@ -65,8 +65,6 @@ static inline void
 command_blit_damage(region_t *damage, region_t *scratch_region, struct backend_command *cmd1,
                     struct backend_command *cmd2, const struct layout_manager *lm,
                     unsigned layer_index, unsigned buffer_age) {
-	auto origin1 = ivec2_add(cmd1->origin, cmd1->mask.origin);
-	auto origin2 = ivec2_add(cmd2->origin, cmd2->mask.origin);
 	// clang-format off
 	// First part, if any blit argument that would affect the whole image changed
 	if (cmd1->blit.dim     != cmd2->blit.dim                   ||
@@ -83,8 +81,8 @@ command_blit_damage(region_t *damage, region_t *scratch_region, struct backend_c
 	         !ivec2_eq(cmd1->blit.effective_size, cmd2->blit.effective_size)))
 	   )
 	{
-		region_union(damage, origin1, &cmd1->mask.region);
-		region_union(damage, origin2, &cmd2->mask.region);
+		pixman_region32_union(damage, damage, &cmd1->target_mask);
+		pixman_region32_union(damage, damage, &cmd2->target_mask);
 		return;
 	}
 	// clang-format on
@@ -96,13 +94,13 @@ command_blit_damage(region_t *damage, region_t *scratch_region, struct backend_c
 	// Damage from layers below that is covered up by the current layer, won't be
 	// visible. So remove them.
 	pixman_region32_subtract(damage, damage, &cmd2->opaque_region);
-	region_symmetric_difference(damage, scratch_region, origin1, &cmd1->mask.region,
-	                            origin2, &cmd2->mask.region);
+	region_symmetric_difference_local(damage, scratch_region, &cmd1->target_mask,
+	                                  &cmd2->target_mask);
 	if (cmd1->source == BACKEND_COMMAND_SOURCE_WINDOW) {
 		layout_manager_collect_window_damage(lm, layer_index, buffer_age,
 		                                     scratch_region);
-		region_intersect(scratch_region, origin1, &cmd1->mask.region);
-		region_intersect(scratch_region, origin2, &cmd2->mask.region);
+		pixman_region32_intersect(scratch_region, scratch_region, &cmd1->target_mask);
+		pixman_region32_intersect(scratch_region, scratch_region, &cmd2->target_mask);
 		pixman_region32_union(damage, damage, scratch_region);
 	}
 }
@@ -110,24 +108,22 @@ command_blit_damage(region_t *damage, region_t *scratch_region, struct backend_c
 static inline void command_blur_damage(region_t *damage, region_t *scratch_region,
                                        struct backend_command *cmd1,
                                        struct backend_command *cmd2, ivec2 blur_size) {
-	auto origin1 = ivec2_add(cmd1->origin, cmd1->mask.origin);
-	auto origin2 = ivec2_add(cmd2->origin, cmd2->mask.origin);
 	if (cmd1->blur.opacity != cmd2->blur.opacity) {
-		region_union(damage, origin1, &cmd1->mask.region);
-		region_union(damage, origin2, &cmd2->mask.region);
+		pixman_region32_union(damage, damage, &cmd1->target_mask);
+		pixman_region32_union(damage, damage, &cmd2->target_mask);
 		return;
 	}
 	if (cmd1->blur.opacity == 0) {
 		return;
 	}
-	region_symmetric_difference(damage, scratch_region, origin1, &cmd1->mask.region,
-	                            origin2, &cmd2->mask.region);
+	region_symmetric_difference_local(damage, scratch_region, &cmd1->target_mask,
+	                                  &cmd2->target_mask);
 
 	// We need to expand the damage region underneath the blur. Because blur
 	// "diffuses" the changes from below.
 	pixman_region32_copy(scratch_region, damage);
 	resize_region_in_place(scratch_region, blur_size.width, blur_size.height);
-	region_intersect(scratch_region, origin2, &cmd2->mask.region);
+	pixman_region32_intersect(scratch_region, scratch_region, &cmd2->target_mask);
 	pixman_region32_union(damage, damage, scratch_region);
 }
 
@@ -294,7 +290,7 @@ void layout_manager_damage(struct layout_manager *lm, unsigned buffer_age,
 }
 
 void commands_cull_with_damage(struct layout *layout, const region_t *damage,
-                               ivec2 blur_size, struct backend_mask *culled_mask) {
+                               ivec2 blur_size, region_t *culled_mask) {
 	// This may sound silly, and probably actually is. Why do GPU's job on the CPU?
 	// Isn't the GPU supposed to be the one that does culling, depth testing etc.?
 	//
@@ -317,36 +313,27 @@ void commands_cull_with_damage(struct layout *layout, const region_t *damage,
 	pixman_region32_copy(&scratch_region, damage);
 	for (int i = to_int_checked(layout->number_of_commands - 1); i >= 0; i--) {
 		auto cmd = &layout->commands[i];
-		ivec2 mask_origin;
-		if (cmd->op != BACKEND_COMMAND_COPY_AREA) {
-			mask_origin = ivec2_add(cmd->origin, cmd->mask.origin);
-		} else {
-			mask_origin = cmd->origin;
-		}
-		region_t tmp_region = culled_mask[i].region;
-		culled_mask[i] = cmd->mask;
-		culled_mask[i].region = tmp_region;
-		pixman_region32_copy(&culled_mask[i].region, &cmd->mask.region);
-		region_intersect(&culled_mask[i].region, ivec2_neg(mask_origin),
-		                 &scratch_region);
+		pixman_region32_copy(&culled_mask[i], &cmd->target_mask);
+		pixman_region32_intersect(&culled_mask[i], &culled_mask[i], &scratch_region);
 		switch (cmd->op) {
 		case BACKEND_COMMAND_BLIT:
 			pixman_region32_subtract(&scratch_region, &scratch_region,
 			                         &cmd->opaque_region);
-			cmd->blit.mask = &culled_mask[i];
+			cmd->blit.target_mask = &culled_mask[i];
 			break;
 		case BACKEND_COMMAND_COPY_AREA:
-			region_subtract(&scratch_region, mask_origin, &cmd->mask.region);
-			cmd->copy_area.region = &culled_mask[i].region;
+			pixman_region32_subtract(&scratch_region, &scratch_region,
+			                         &cmd->target_mask);
+			cmd->copy_area.region = &culled_mask[i];
 			break;
 		case BACKEND_COMMAND_BLUR:
 			// To render blur, the layers below must render pixels surrounding
 			// the blurred area in this layer.
 			pixman_region32_copy(&tmp, &scratch_region);
-			region_intersect(&tmp, mask_origin, &cmd->mask.region);
+			pixman_region32_intersect(&tmp, &tmp, &cmd->target_mask);
 			resize_region_in_place(&tmp, blur_size.width, blur_size.height);
 			pixman_region32_union(&scratch_region, &scratch_region, &tmp);
-			cmd->blur.mask = &culled_mask[i];
+			cmd->blur.target_mask = &culled_mask[i];
 			break;
 		case BACKEND_COMMAND_INVALID: assert(false);
 		}
@@ -359,10 +346,10 @@ void commands_uncull(struct layout *layout) {
 	for (auto i = layout->commands;
 	     i != &layout->commands[layout->number_of_commands]; i++) {
 		switch (i->op) {
-		case BACKEND_COMMAND_BLIT: i->blit.mask = &i->mask; break;
-		case BACKEND_COMMAND_BLUR: i->blur.mask = &i->mask; break;
+		case BACKEND_COMMAND_BLIT: i->blit.target_mask = &i->target_mask; break;
+		case BACKEND_COMMAND_BLUR: i->blur.target_mask = &i->target_mask; break;
 		case BACKEND_COMMAND_COPY_AREA:
-			i->copy_area.region = &i->mask.region;
+			i->copy_area.region = &i->target_mask;
 			break;
 		case BACKEND_COMMAND_INVALID: assert(false);
 		}

--- a/src/renderer/damage.h
+++ b/src/renderer/damage.h
@@ -13,9 +13,9 @@ struct backend_mask;
 /// retained, so later the commands can be "un-culled".
 ///
 /// @param culled_mask use to stored the culled masks, must be have space to store at
-///                    least `layout->number_of_commands` elements. They MUST NOT have
-///                    initialized regions. This function will initialize their regions.
-///                    These masks MUST NOT be freed until you call `commands_uncull`.
+///                    least `layout->number_of_commands` elements. They MUST be
+///                    initialized before calling this function. These masks MUST NOT be
+///                    freed until you call `commands_uncull`.
 void commands_cull_with_damage(struct layout *layout, const region_t *damage,
                                ivec2 blur_size, struct backend_mask *culled_mask);
 

--- a/src/renderer/damage.h
+++ b/src/renderer/damage.h
@@ -17,7 +17,7 @@ struct backend_mask;
 ///                    initialized before calling this function. These masks MUST NOT be
 ///                    freed until you call `commands_uncull`.
 void commands_cull_with_damage(struct layout *layout, const region_t *damage,
-                               ivec2 blur_size, struct backend_mask *culled_mask);
+                               ivec2 blur_size, region_t *culled_mask);
 
 /// Un-do the effect of `commands_cull_with_damage`
 void commands_uncull(struct layout *layout);

--- a/src/win.c
+++ b/src/win.c
@@ -107,7 +107,7 @@ static void win_mark_client(session_t *ps, struct managed_win *w, xcb_window_t c
 #define gen_without_corners(fun)                                                         \
 	void fun##_without_corners(const struct managed_win *w, region_t *res) {         \
 		fun(w, res);                                                             \
-		win_region_remove_corners(w, res);                                       \
+		win_region_remove_corners_local(w, res);                                 \
 	}
 
 /// Generate a "return by value" function, from a function that returns the


### PR DESCRIPTION
When trying to add source image transformation (e.g. scaling), I realized it's ambiguous whether the mask should be applied before or after the transformation. And after further thought, I decided it would be better to have two separate masks, one for the source, which would be in the source's coordinate system (i.e. before any transformation); and one for the target.

And due to how we currently use the mask, I made the source mask an image, and the target mask a region. Nothing is stopping us from making both a combination of an image and a region, but we won't be using that capability anyway.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
