### PR TITLE
wm/win: implement EWMH WM_TRANSIENT_FOR extension

### DIFF
--- a/src/inspect.c
+++ b/src/inspect.c
@@ -63,8 +63,10 @@ setup_window(struct x_connection *c, struct atom *atoms, struct options *options
 
 	// Determine if the window is focused
 	xcb_window_t wid = XCB_NONE;
+	bool exists;
 	if (options->use_ewmh_active_win) {
-		wid_get_prop_window(c, c->screen_info->root, atoms->a_NET_ACTIVE_WINDOW);
+		wid_get_prop_window(c, c->screen_info->root, atoms->a_NET_ACTIVE_WINDOW,
+		                    &exists);
 	} else {
 		// Determine the currently focused window so we can apply appropriate
 		// opacity on it

--- a/src/picom.c
+++ b/src/picom.c
@@ -457,8 +457,10 @@ void add_damage(session_t *ps, const region_t *damage) {
  */
 void update_ewmh_active_win(session_t *ps) {
 	// Search for the window
+	bool exists;
 	xcb_window_t wid = wid_get_prop_window(&ps->c, ps->c.screen_info->root,
-	                                       ps->atoms->a_NET_ACTIVE_WINDOW);
+	                                       ps->atoms->a_NET_ACTIVE_WINDOW, &exists);
+
 	auto cursor = wm_find_by_client(ps->wm, wid);
 	auto w = cursor ? wm_ref_deref(cursor) : NULL;
 

--- a/src/x.c
+++ b/src/x.c
@@ -284,14 +284,18 @@ winprop_info_t x_get_prop_info(const struct x_connection *c, xcb_window_t w, xcb
  *
  * @return the value if successful, 0 otherwise
  */
-xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid, xcb_atom_t aprop) {
+xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid,
+                                 xcb_atom_t aprop, bool *exists) {
 	// Get the attribute
 	xcb_window_t p = XCB_NONE;
 	winprop_t prop = x_get_prop(c, wid, aprop, 1L, XCB_ATOM_WINDOW, 32);
 
 	// Return it
 	if (prop.nitems) {
+		*exists = true;
 		p = (xcb_window_t)*prop.p32;
+	} else {
+		*exists = false;
 	}
 
 	free_winprop(&prop);

--- a/src/x.h
+++ b/src/x.h
@@ -249,7 +249,8 @@ static inline void x_discard_events(struct x_connection *c) {
  *
  * @return the value if successful, 0 otherwise
  */
-xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid, xcb_atom_t aprop);
+xcb_window_t wid_get_prop_window(struct x_connection *c, xcb_window_t wid,
+                                 xcb_atom_t aprop, bool *exists);
 
 /**
  * Get the value of a text property of a window.


### PR DESCRIPTION
In EWMH the meaning of WM_TRANSIENT_FOR is extended, so that when it's set to the root window or None, the window is considered transient for all windows in the same window group.

We implement this by using the window group leader as the leader.

Also make win_get_leader_raw robust against invalid leader values.

Fixes #1278

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
