### PR TITLE
config: add --inactive-dim-exclude for inactive dim blacklisting

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -702,6 +702,7 @@ bool parse_config(options_t *opt, const char *config_file) {
 	    .window_shader_fg = NULL,
 	    .window_shader_fg_rules = NULL,
 	    .inactive_dim = 0.0,
+	    .inactive_dim_blacklist = NULL,
 	    .inactive_dim_fixed = false,
 	    .invert_color_list = NULL,
 	    .opacity_rules = NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -295,6 +295,8 @@ typedef struct options {
 	/// Whether to use fixed inactive dim opacity, instead of deciding
 	/// based on window opacity.
 	bool inactive_dim_fixed;
+	/// Inactive dim blacklist. A linked list of conditions.
+	c2_lptr_t *inactive_dim_blacklist;
 	/// Conditions of windows to have inverted colors.
 	c2_lptr_t *invert_color_list;
 	/// Rules to change window opacity.

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -818,6 +818,7 @@ bool parse_config_libconfig(options_t *opt, const char *config_file) {
 	if (!parse_cfg_condlst(&cfg, &opt->transparent_clipping_blacklist,
 	                       "transparent-clipping-exclude") ||
 	    !parse_cfg_condlst(&cfg, &opt->shadow_blacklist, "shadow-exclude") ||
+	    !parse_cfg_condlst(&cfg, &opt->inactive_dim_blacklist, "inactive-dim-exclude") ||
 	    !parse_cfg_condlst(&cfg, &opt->shadow_clip_list, "clip-shadow-above") ||
 	    !parse_cfg_condlst(&cfg, &opt->fade_blacklist, "fade-exclude") ||
 	    !parse_cfg_condlst(&cfg, &opt->focus_blacklist, "focus-exclude") ||

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -245,6 +245,8 @@ int inspect_main(int argc, char **argv, const char *config_file) {
 	                &match_state);
 	printf("Checking " BOLD("shadow-exclude") ":\n");
 	c2_list_foreach(options.shadow_blacklist, c2_match_once_and_log, &match_state);
+	printf("Checking " BOLD("inactive-dim-exclude") ":\n");
+	c2_list_foreach(options.inactive_dim_blacklist, c2_match_once_and_log, &match_state);
 	printf("Checking " BOLD("fade-exclude") ":\n");
 	c2_list_foreach(options.fade_blacklist, c2_match_once_and_log, &match_state);
 	printf("Checking " BOLD("clip-shadow-above") ":\n");

--- a/src/options.c
+++ b/src/options.c
@@ -444,6 +444,7 @@ static const struct picom_option picom_options[] = {
 
     // Rules
     [263] = {"shadow-exclude"              , RULES(shadow_blacklist)              , "Exclude conditions for shadows."},
+    [273] = {"inactive-dim-exclude"        , RULES(inactive_dim_blacklist)        , "Exclude conditions for inactive dim."},
     [279] = {"focus-exclude"               , RULES(focus_blacklist)               , "Specify a list of conditions of windows that should always be considered focused."},
     [288] = {"invert-color-include"        , RULES(invert_color_list)             , "Specify a list of conditions of windows that should be painted with "
                                                                                     "inverted color."},
@@ -957,6 +958,7 @@ void options_postprocess_c2_lists(struct c2_state *state, struct x_connection *c
 	if (!(c2_list_postprocess(state, c->c, option->unredir_if_possible_blacklist) &&
 	      c2_list_postprocess(state, c->c, option->paint_blacklist) &&
 	      c2_list_postprocess(state, c->c, option->shadow_blacklist) &&
+	      c2_list_postprocess(state, c->c, option->inactive_dim_blacklist) &&
 	      c2_list_postprocess(state, c->c, option->shadow_clip_list) &&
 	      c2_list_postprocess(state, c->c, option->fade_blacklist) &&
 	      c2_list_postprocess(state, c->c, option->blur_background_blacklist) &&
@@ -975,6 +977,7 @@ void options_postprocess_c2_lists(struct c2_state *state, struct x_connection *c
 void options_destroy(struct options *options) {
 	// Free blacklists
 	c2_list_free(&options->shadow_blacklist, NULL);
+	c2_list_free(&options->inactive_dim_blacklist, NULL);
 	c2_list_free(&options->shadow_clip_list, NULL);
 	c2_list_free(&options->fade_blacklist, NULL);
 	c2_list_free(&options->focus_blacklist, NULL);

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -846,9 +846,15 @@ bool win_should_dim(session_t *ps, const struct win *w) {
 		return false;
 	}
 
+	if (c2_match(ps->c2_state, w, ps->o.inactive_dim_blacklist, NULL)) {
+		log_debug("Dim disabled by inactive-dim-exclude");
+		return false;
+	}
+
 	if (ps->o.inactive_dim > 0 && !(w->focused)) {
 		return true;
 	}
+
 	return false;
 }
 


### PR DESCRIPTION
Add  `--inactive-dim-exclude COND` config. I just wanted to watch videos in my video player while browsing the web without the video player being dimmed. Maybe should be other use cases.

Also, I think this option makes `--inactive-dim-*` configurations a bit more consistent with `--blur-*` and `--shadow-*`.

Thank you!