### PR TITLE
Build debian: Add `libxcb-xinerama0-dev` as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 On Debian based distributions (e.g. Ubuntu), the needed packages are
 
 ```
-libconfig-dev libdbus-1-dev libegl-dev libev-dev libgl-dev libepoxy-dev libpcre2-dev libpixman-1-dev libx11-xcb-dev libxcb1-dev libxcb-composite0-dev libxcb-damage0-dev libxcb-glx0-dev libxcb-image0-dev libxcb-present-dev libxcb-randr0-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-shape0-dev libxcb-util-dev libxcb-xfixes0-dev meson ninja-build uthash-dev
+libconfig-dev libdbus-1-dev libegl-dev libev-dev libgl-dev libepoxy-dev libpcre2-dev libpixman-1-dev libx11-xcb-dev libxcb1-dev libxcb-composite0-dev libxcb-damage0-dev libxcb-glx0-dev libxcb-image0-dev libxcb-present-dev libxcb-randr0-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-shape0-dev libxcb-util-dev libxcb-xfixes0-dev meson ninja-build uthash-dev libxcb-xinerama0-dev
 ```
 
 On Fedora, the needed packages are


### PR DESCRIPTION
My build on Ubuntu 22.04 succeeded, but only after installing `libxcb-xinerama0-dev`. I assume certain flavors of debian-basd systems need to have xcb-xinerama explicitly.

```shell
# following installation instructions from README.md
sudo apt-get install libconfig-dev libdbus-1-dev libegl-dev libev-dev libgl-dev libepoxy-dev libpcre2-dev libpixman-1-dev libx11-xcb-dev libxcb1-dev libxcb-composite0-dev libxcb-damage0-dev libxcb-glx0-dev libxcb-image0-dev libxcb-present-dev libxcb-randr0-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-shape0-dev libxcb-util-dev libxcb-xfixes0-dev meson ninja-build uthash-dev
meson setup --buildtype=release build

src/meson.build:31:1: ERROR: Dependency "xcb-xinerama" not found, tried pkgconfig and cmake

sudo apt-get install libxcb-xinerama0-dev
# Now build worked
```