### PR TITLE
gl: fix for correct display of window borders during animation

### DIFF
--- a/src/opengl.c
+++ b/src/opengl.c
@@ -797,10 +797,7 @@ bool glx_bind_pixmap(session_t *ps, glx_texture_t **pptex, xcb_pixmap_t pixmap, 
 
 		glTexParameteri(ptex->target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(ptex->target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		if (repeat) {
-			glTexParameteri(ptex->target, GL_TEXTURE_WRAP_S, GL_REPEAT);
-			glTexParameteri(ptex->target, GL_TEXTURE_WRAP_T, GL_REPEAT);
-		} else {
+		if (!repeat) {
 			glTexParameteri(ptex->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 			glTexParameteri(ptex->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		}

--- a/src/render.c
+++ b/src/render.c
@@ -422,7 +422,7 @@ void paint_one(session_t *ps, struct win *w, const region_t *reg_paint) {
 	// Let glx_bind_pixmap() determine pixmap size, because if the user
 	// is resizing windows, the width and height we get may not be up-to-date,
 	// causing the jittering issue M4he reported in #7.
-	if (!paint_bind_tex(ps, &w->paint, 0, 0, false, 0, w->a.visual,
+	if (!paint_bind_tex(ps, &w->paint, 0, 0, true, 0, w->a.visual,
 	                    (!ps->o.glx_no_rebind_pixmap && w->pixmap_damaged))) {
 		log_error("Failed to bind texture for window %#010x.", win_id(w));
 	}
@@ -763,7 +763,7 @@ shadow_picture_err:
  */
 static inline void win_paint_shadow(session_t *ps, struct win *w, region_t *reg_paint) {
 	// Bind shadow pixmap to GLX texture if needed
-	paint_bind_tex(ps, &w->shadow_paint, 0, 0, false, 32, 0, false);
+	paint_bind_tex(ps, &w->shadow_paint, 0, 0, true, 32, 0, false);
 
 	if (!paint_isvalid(ps, &w->shadow_paint)) {
 		log_error("Window %#010x is missing shadow data.", win_id(w));
@@ -1287,8 +1287,8 @@ void paint_all(session_t *ps, struct win *t) {
 		}
 		glXWaitX();
 		assert(ps->tgt_buffer.pixmap);
-		paint_bind_tex(ps, &ps->tgt_buffer, ps->root_width, ps->root_height,
-		               false, ps->c.screen_info->root_depth,
+		paint_bind_tex(ps, &ps->tgt_buffer, ps->root_width, ps->root_height, true,
+		               ps->c.screen_info->root_depth,
 		               ps->c.screen_info->root_visual, !ps->o.glx_no_rebind_pixmap);
 		if (ps->o.vsync_use_glfinish) {
 			glFinish();


### PR DESCRIPTION
This PR sets the texture parameters to GL_REPEAT (default value), which corrects this visual defect in animation:

![picom](https://github.com/user-attachments/assets/204bdb96-2906-4600-bc89-24dff33fd761)
