### PR TITLE
core: fixed segmentation fault in handle_pending_updates

### DIFF
--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -235,6 +235,13 @@ static inline void win_release_mask(backend_t *base, struct win *w) {
 	}
 }
 
+static inline void win_release_saved_win_image(backend_t *base, struct win *w) {
+	if (w->saved_win_image) {
+		base->ops.release_image(base, w->saved_win_image);
+		w->saved_win_image = NULL;
+	}
+}
+
 void win_release_images(struct backend_base *backend, struct win *w) {
 	// We don't want to decide what we should do if the image we want to
 	// release is stale (do we clear the stale flags or not?) But if we are
@@ -244,6 +251,7 @@ void win_release_images(struct backend_base *backend, struct win *w) {
 	win_release_pixmap(backend, w);
 	win_release_shadow(backend, w);
 	win_release_mask(backend, w);
+	win_release_saved_win_image(backend, w);
 }
 
 /// Returns true if the `prop` property is stale, as well as clears the stale


### PR DESCRIPTION
You can invoke it if you quickly switch between the full-screen window and other windows. Most likely the callback call occurs at the moment when the backend has already been destroyed.

```
Program received signal SIGSEGV, Segmentation fault.
handle_pending_updates (ps=0x5555556b4530, delta_t=0) at ../src/picom.c:1668
1668					ps->backend_data->ops.release_image(ps->backend_data,
(gdb) back
#0  handle_pending_updates (ps=0x5555556b4530, delta_t=0) at ../src/picom.c:1668
#1  0x0000555555594061 in draw_callback_impl (loop=0x7ffff7ea8720, ps=0x5555556b4530, revents=256) at ../src/picom.c:1724
#2  0x0000555555594bc4 in draw_callback (loop=0x7ffff7ea8720, w=0x5555556b4590, revents=256) at ../src/picom.c:1925
#3  0x00007ffff7e9c773 in ev_invoke_pending () from /lib/x86_64-linux-gnu/libev.so.4
#4  0x00007ffff7ea0041 in ev_run () from /lib/x86_64-linux-gnu/libev.so.4
#5  0x00005555555993cb in session_run (ps=0x5555556b4530) at ../src/picom.c:2738
#6  0x0000555555599752 in main (argc=1, argv=0x7fffffffde28) at ../src/picom.c:2853
(gdb) 0
Undefined command: "0".  Try "help".
(gdb) step 0

Program received signal SIGSEGV, Segmentation fault.
handle_pending_updates (ps=0x5555556b4530, delta_t=0) at ../src/picom.c:1668
1668					ps->backend_data->ops.release_image(ps->backend_data,
(gdb) list
1663				free(w->running_animation_instance);
1664				w->running_animation_instance = NULL;
1665				w->in_openclose = false;
1666				if (w->saved_win_image != NULL) {
1667					printf("%c\n", ps->backend_data);
1668					ps->backend_data->ops.release_image(ps->backend_data,
1669					                                    w->saved_win_image);
1670					w->saved_win_image = NULL;
1671				}
1672				if (w->state == WSTATE_UNMAPPED) {
(gdb) w
watch           wh              whatis          where           while           while-stepping  winheight       with            ws              
(gdb) p /s w
$1 = (struct win *) 0x55555570cff0
(gdb) p /s ps
$2 = (struct session *) 0x5555556b4530
(gdb) p /s ps->backend_data
$3 = (backend_t *) 0x0
```