### PR TITLE
wm: fixed segmentation fault in wm_find_leader

### DIFF
--- a/src/wm/wm.c
+++ b/src/wm/wm.c
@@ -225,6 +225,9 @@ static struct wm_tree_node *wm_find_leader(struct wm *wm, struct wm_tree_node *n
 			return node->leader_final;
 		}
 		leader_node = wm_tree_find_toplevel_for(&wm->tree, leader_node);
+		if (leader_node == NULL) {
+			return node->leader_final;
+		}
 		node->visited = true;
 		node->leader_final = wm_find_leader(wm, leader_node);
 		node->visited = false;


### PR DESCRIPTION
I triggered this by simply opening OpenMPT, which first shows the application logo and then opens the main window.

```
Program received signal SIGSEGV, Segmentation fault.
0x00005555555db17d in wm_find_leader (wm=0x5555556c1470, node=0x0) at ../src/wm/wm.c:212
212             if (node->leader_final != NULL) {
(gdb) back
#0  0x00005555555db17d in wm_find_leader (wm=0x5555556c1470, node=0x0) at ../src/wm/wm.c:212
#1  0x00005555555db28b in wm_find_leader (wm=0x5555556c1470, node=0x5555556ebab0) at ../src/wm/wm.c:229
#2  0x00005555555db39e in wm_refresh_leaders (wm=0x5555556c1470) at ../src/wm/wm.c:251
#3  0x0000555555593b97 in refresh_windows (ps=0x5555556b6580) at ../src/picom.c:1625
#4  0x0000555555593d3b in handle_pending_updates (ps=0x5555556b6580, delta_t=0.014999999999999999) at ../src/picom.c:1662
#5  0x00005555555942b0 in draw_callback_impl (loop=0x7ffff7ea8720, ps=0x5555556b6580, revents=256) at ../src/picom.c:1732
#6  0x0000555555594e13 in draw_callback (loop=0x7ffff7ea8720, w=0x5555556b65e0, revents=256) at ../src/picom.c:1933
#7  0x00007ffff7e9c773 in ev_invoke_pending () from /lib/x86_64-linux-gnu/libev.so.4
#8  0x00007ffff7ea0041 in ev_run () from /lib/x86_64-linux-gnu/libev.so.4
#9  0x00005555555995eb in session_run (ps=0x5555556b6580) at ../src/picom.c:2746
#10 0x0000555555599972 in main (argc=1, argv=0x7fffffffe358) at ../src/picom.c:2861
```