### PR TITLE
Fix rendering errors on enabling/resizing monitors

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -388,13 +388,13 @@ static inline void ev_configure_notify(session_t *ps, xcb_configure_notify_event
 		return;
 	}
 
-	if (ev->window == ev->event) {
-		return;
-	}
-
 	if (ev->window == ps->c.screen_info->root) {
 		configure_root(ps);
 	} else {
+		if (ev->window == ev->event) {
+			return;
+		}
+
 		configure_win(ps, ev);
 	}
 }


### PR DESCRIPTION
See issue #1338 - commit 0aa6202 introduced a problem with display changes, where root window Configure events would be ignored due to the new conditional, since the event comes from the root window itself. This is a small PR just moving that conditional, to make sure that root window events are always processed, and the filter only applies on other windows.