### PR TITLE
fix various memory leaks 

### DIFF
--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -283,6 +283,7 @@ err:
 	if (eglpixmap && *eglpixmap) {
 		eglDestroyImage(gd->display, *eglpixmap);
 	}
+	free(inner);
 	free(eglpixmap);
 	return NULL;
 }

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -444,6 +444,7 @@ err:
 	if (glxpixmap && *glxpixmap) {
 		glXDestroyPixmap(base->c->dpy, *glxpixmap);
 	}
+	free(inner);
 	free(glxpixmap);
 	return NULL;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -487,9 +487,11 @@ char *locate_auxiliary_file(const char *scope, const char *path, const char *inc
 	if (config_home) {
 		char *ret = locate_auxiliary_file_at(config_home, picom_scope, path);
 		if (ret) {
+			free(config_home);
 			return ret;
 		}
 	}
+	free(config_home);
 
 	// Fall back to searching in system config directory
 	auto config_dirs = xdg_config_dirs();
@@ -581,6 +583,7 @@ void parse_debug_options(struct debug_options *debug_options) {
 		parse_debug_option_single(needle, debug_options);
 		needle = strtok_r(NULL, ";", &tmp);
 	}
+	free(debug_copy);
 }
 
 void *parse_window_shader_prefix(const char *src, const char **end, void *user_data) {
@@ -609,6 +612,7 @@ void *parse_window_shader_prefix(const char *src, const char **end, void *user_d
 	char *tmp = (char *)trim_both(untrimed_shader_source, &length);
 	tmp[length] = '\0';
 	char *shader_source = NULL;
+	free(untrimed_shader_source);
 
 	if (strcasecmp(tmp, "default") != 0) {
 		shader_source = locate_auxiliary_file("shaders", tmp, include_dir);

--- a/src/transition/script.c
+++ b/src/transition/script.c
@@ -998,8 +998,8 @@ script_compile(config_setting_t *setting, struct script_parse_config cfg, char *
 		struct script_context_info_internal *info, *next_info;
 		HASH_ITER(hh, context_table, info, next_info) {
 			HASH_DEL(context_table, info);
-			free(info);
 		}
+		free(info);
 	}
 	for (int i = 0; cfg.output_info && cfg.output_info[i].name; i++) {
 		struct variable_allocation *alloc = NULL;


### PR DESCRIPTION
Hi, this changes fix a few memory leaks detected by clang-static-analyzer. The fixes are in backend/egl.c, backend/glx.c, src/config.c and transition/script.c

There are other issues detected, but touching them will break picom, so we'll have to keep checking these new fixes. At the moment, these fixes work perfectly on my machine (FreeBSD) for both amd64 and i386.

As I fix the rest of the bugs detected with clang-static-analyzer, I'll upload the rest of the commits.

