### PR TITLE
fix: nix overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,9 +18,8 @@
     let
       # like lib.lists.remove, but takes a list of elements to remove
       removeFromList = toRemove: list: pkgs.lib.foldl (l: e: pkgs.lib.remove e l) list toRemove;
-      picomOverlay = final: prev: { picom = prev.callPackage ./package.nix { }; };
+      picomOverlay = final: prev: { picom = prev.callPackage ./package.nix { inherit git-ignore-nix; }; };
       overlays = [
-        (final: prev: { inherit git-ignore-nix; })
         picomOverlay
       ];
       pkgs = import nixpkgs {


### PR DESCRIPTION
# Error info

After some recent changes, flake overlays stopped working, narrowing down the problem this is probably because of doing overlay for git-ignore-nix which is not a package but a flake (so the package can't really receive that git-ignore-nix). Passing git-ignore-nix as a direct argument to the package fixes the overlay usage for me, should work for others too.

# Example of error

```sh
error: evaluation aborted with the following error message: 'lib.customisation.callPackageWith: Function called without required argument "git-ignore-nix"
```
