### PR TITLE
fix logging related to shader loading

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -2078,7 +2078,7 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 
 	// Load shader source file specified in the shader rules
 	c2_condition_list_foreach(&ps->o.window_shader_fg_rules, i) {
-		if (!load_shader_source(ps, c2_condition_get_data(i))) {
+		if (load_shader_source(ps, c2_condition_get_data(i))) {
 			log_error("Failed to load shader source file for some of the "
 			          "window shader rules");
 		}

--- a/src/picom.c
+++ b/src/picom.c
@@ -1851,6 +1851,7 @@ static bool load_shader_source(session_t *ps, const char *path) {
 		          path, read_bytes, num_bytes);
 		goto err;
 	}
+	fclose(f);
 	return false;
 err:
 	HASH_DEL(ps->shaders, shader);


### PR DESCRIPTION
# Changelog
* Category: Bug fixes
* Description:
  * Fixed check for error when loading shaders via fg-window-rules (inverted condition)
  * I think the opened shader files are not properly closed when successfully read, so I added a fclose for the happy path
