### PR TITLE
picom: add damage to windows that have animated shaders

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -715,6 +715,7 @@ static bool paint_preprocess(session_t *ps, bool *animation, struct win **out_bo
 			HASH_FIND_STR(ps->shaders, window_options.shader, fg_shader);
 		}
 		if (fg_shader != NULL && fg_shader->attributes & SHADER_ATTRIBUTE_ANIMATED) {
+			pixman_region32_copy(&w->damaged, &w->bounding_shape);
 			*animation = true;
 		}
 


### PR DESCRIPTION
### picom: add damage to windows that have animated shaders
done in paint_preprocess because doing this in command_blit_damage or
layer_from_win would be complicated.

Changelog: BugFix: Fix animated shaders.