### PR TITLE
man: Update minimum required OpenGL version

### DIFF
--- a/man/picom.1.adoc
+++ b/man/picom.1.adoc
@@ -225,7 +225,7 @@ May also be one of the predefined kernels: `3x3box` (default), `5x5box`, `7x7box
 +
 --
 * `xrender` backend performs all rendering operations with X Render extension. It is what `xcompmgr` uses, and is generally a safe fallback when you encounter rendering artifacts or instability.
-* `glx` (OpenGL) backend performs all rendering operations with OpenGL. It is more friendly to some VSync methods, and has significantly superior performance on color inversion (*--invert-color-include*) or blur (*--blur-background*). It requires proper OpenGL 2.0 support from your driver and hardware. You may wish to look at the GLX performance optimization options below. *--xrender-sync-fence* might be needed on some systems to avoid delay in changes of screen contents.
+* `glx` (OpenGL) backend performs all rendering operations with OpenGL. It is more friendly to some VSync methods, and has significantly superior performance on color inversion (*--invert-color-include*) or blur (*--blur-background*). It requires proper OpenGL 3.3 support from your driver and hardware. You may wish to look at the GLX performance optimization options below. *--xrender-sync-fence* might be needed on some systems to avoid delay in changes of screen contents.
 --
 
 *--no-use-damage*::


### PR DESCRIPTION
## Summary

Since old backends have been dropped, I think it should be clarified that the current minimum required version of OpenGL is 3.3 (for EGL AFAIK, required version is 4.2, but man page doesn't mention the presence of EGL backend for some reason).

## Checklist

- [x] Enable "Allow edits from maintainers". (So we can make necessary changes).
- [ ] Add changelog entries to commit messages when appropriate. These will be included in release announcements.
  <details>
  Format the changelog entries like this:

  `Changelog: BugFix: Stop picom from summoning the Great Old Ones.`

  The entry starts with `Changelog: `, followed by a category name (`BugFix: ` in this case), then a short description of the changes in the commit.
  <summary>How to format changelog entries</summary>
  </details>
