### PR TITLE
Break out of error loop for GL_CONTEXT_LOST

### DIFF
--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -268,6 +268,10 @@ static inline void gl_check_err_(const char *func, int line) {
 			log_printf(tls_logger, LOG_LEVEL_ERROR, func,
 			           "GL error at line %d: %d", line, err);
 		}
+		if (err == GL_CONTEXT_LOST) {
+			// GL_CONTEXT_LOST repeats until the context is restored.
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
GL_CONTEXT_LOST repeats forever. Prevent an infinite loop by breaking out of the loop when a GL_CONTEXT_LOST error is encountered.

Mostly fixes #1398 