### PR TITLE
why is the example conf of ✨ Picom ✨ so dull? Here's an improved one.

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -1,7 +1,21 @@
-#################################
-#             Shadows           #
-#################################
-
+#================================================================================================;
+# ██████╗  ██╗  ██████╗  ██████╗  ███╗   ███╗
+# ██╔══██╗ ██║ ██╔════╝ ██╔═══██╗ ████╗ ████║
+# ██████╔╝ ██║ ██║      ██║   ██║ ██╔████╔██║
+# ██╔═══╝  ██║ ██║      ██║   ██║ ██║╚██╔╝██║
+# ██║      ██║ ╚██████╗ ╚██████╔╝ ██║ ╚═╝ ██║
+# ╚═╝      ╚═╝  ╚═════╝  ╚═════╝  ╚═╝     ╚═╝
+#
+# 
+#   To learn more about how to configure Picom
+#   go to https://picom.app/
+#
+#   The Documentation contains a lot of information
+#
+#=================================================================================================;
+# ╭──────────────────────────────────────────────╮
+# │                  Shadows                     │
+# ╰──────────────────────────────────────────────╯
 # Enabled client-side shadows on windows. Note desktop windows
 # (windows with '_NET_WM_WINDOW_TYPE_DESKTOP') never get shadow,
 # unless explicitly requested using the wintypes option.
@@ -43,10 +57,9 @@ shadow-offset-y = -7;
 # Default: false
 # crop-shadow-to-monitor = false
 
-
-#################################
-#           Fading              #
-#################################
+# ╭──────────────────────────────────────────────╮
+# │                  Fading                      │
+# ╰──────────────────────────────────────────────╯
 
 # Fade windows in/out when opening/closing and when opacity changes,
 # unless no-fading-openclose is used. Can be set per-window using rules.
@@ -69,10 +82,9 @@ fade-out-step = 0.03;
 # Do not fade destroyed ARGB windows with WM frame. Workaround of bugs in Openbox, Fluxbox, etc.
 # no-fading-destroyed-argb = false
 
-
-#################################
-#   Transparency / Opacity      #
-#################################
+# ╭──────────────────────────────────────────────╮
+# │            Transparency / Opacity            │
+# ╰──────────────────────────────────────────────╯
 
 # Opacity of window titlebars and borders.
 #
@@ -85,9 +97,9 @@ frame-opacity = 0.7;
 # Default: false
 # inactive-dim-fixed = true
 
-#################################
-#           Corners             #
-#################################
+# ╭──────────────────────────────────────────────╮
+# │                  Corners                     │
+# ╰──────────────────────────────────────────────╯
 
 # Sets the radius of rounded window corners. When > 0, the compositor will
 # round the corners of windows. Does not interact well with
@@ -96,9 +108,9 @@ frame-opacity = 0.7;
 # Default: 0 (disabled)
 corner-radius = 0
 
-#################################
-#            Blur               #
-#################################
+# ╭──────────────────────────────────────────────╮
+# │                   Blur                       │
+# ╰──────────────────────────────────────────────╯
 
 # Parameters for background blurring, see BLUR section in the man page for more information.
 # blur-method =
@@ -135,9 +147,9 @@ corner-radius = 0
 # Default: ""
 blur-kern = "3x3box";
 
-#################################
-#       General Settings        #
-#################################
+# ╭──────────────────────────────────────────────╮
+# │              General Settings                │
+# ╰──────────────────────────────────────────────╯
 
 # Enable remote control via D-Bus. See the man page for more details.
 #


### PR DESCRIPTION
Update comments and formatting in picom.sample.conf

Note: I didn't change anything from the default example conf. I just made it a bit prettier with heading and beautiful borders for titles. As you can see in the changes.

