### PR TITLE
animation: fix position detection when size also changes

### DIFF
--- a/src/wm/win.h
+++ b/src/wm/win.h
@@ -392,10 +392,6 @@ static inline bool win_size_changed(struct win_geometry a, struct win_geometry b
 
 /// Check if the window position has changed.
 static inline bool win_position_changed(struct win_geometry a, struct win_geometry b) {
-	if (win_size_changed(a, b)) {
-		return false;
-	}
-
 	return a.x != b.x || a.y != b.y;
 }
 


### PR DESCRIPTION
## Summary

Fixes `win_position_changed()` to correctly detect position changes even when size has also changed.

## Problem

In tiling window managers, when windows change both position AND size simultaneously (e.g., when a new window opens and existing windows are rearranged), the position change was not being detected because `win_position_changed()` returned `false` if size also changed.

This caused only SIZE triggers to fire, preventing POSITION or GEOMETRY animations from working properly.

## Solution

Remove the incorrect early return that prevented position detection when size changed. Now position changes are detected regardless of whether size changed, allowing POSITION triggers to fire correctly.

Since POSITION is checked before SIZE in the trigger priority, this ensures geometry animations work properly for windows that move and resize simultaneously.

## Test plan
- Configure geometry animations with position triggers in a tiling WM
- Open new windows that cause existing windows to move and resize
- Verify all displaced windows animate their position changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)