### PR TITLE
picom.conf: warn that glx is slower than xrender

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -158,6 +158,7 @@ blur-kern = "3x3box";
 
 # Specify the backend to use: `xrender`, `glx`, or `egl`.
 #
+# glx is much slower, and should not be used when not using advanced features, such as blur, that require it.
 # Default: "xrender"
 backend = "glx"
 


### PR DESCRIPTION
Much higher CPU usage when picom uses glx, as opposed to xrender, as the backend.